### PR TITLE
Add .oqtane-ref/ to .gitignore for local dev tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -419,3 +419,6 @@ FodyWeavers.xsd
 *.msp
 /OpenEug.TenTrees/.playwright-mcp
 /OpenEug.TenTrees/Server/appsettings.Production.json
+
+# Oqtane framework reference clone (local dev tool, never committed)
+.oqtane-ref/


### PR DESCRIPTION
## Summary
Updated the `.gitignore` file to exclude the `.oqtane-ref/` directory, which is used as a local development tool for referencing the Oqtane framework during development.

## Changes
- Added `.oqtane-ref/` directory to `.gitignore` with an explanatory comment indicating it's a local development tool that should never be committed to the repository

## Details
This prevents accidental commits of the local Oqtane framework reference clone, keeping the repository clean and ensuring developers can maintain their own local copies without affecting version control.

https://claude.ai/code/session_0153USte2ZfoUzPF385khmrT