### PR TITLE
Add @page directives to module Index components

### DIFF
--- a/Client/Modules/Assessment/Index.razor
+++ b/Client/Modules/Assessment/Index.razor
@@ -1,6 +1,7 @@
 @using OpenEug.TenTrees.Module.Assessment.Services
 @using OpenEug.TenTrees.Module.Grower.Services
 @using OpenEug.TenTrees.Models
+@page "/assessment"
 
 @namespace OpenEug.TenTrees.Module.Assessment
 @inherits ModuleBase

--- a/Client/Modules/Enrollment/Index.razor
+++ b/Client/Modules/Enrollment/Index.razor
@@ -1,6 +1,7 @@
 @using OpenEug.TenTrees.Module.Enrollment.Services
 @using OpenEug.TenTrees.Module.Village.Services
 @using OpenEug.TenTrees.Models
+@page "/enrollment"
 
 @namespace OpenEug.TenTrees.Module.Enrollment
 @inherits ModuleBase

--- a/Client/Modules/Grower/Index.razor
+++ b/Client/Modules/Grower/Index.razor
@@ -1,6 +1,7 @@
 @using OpenEug.TenTrees.Module.Grower.Services
 @using OpenEug.TenTrees.Module.Village.Services
 @using OpenEug.TenTrees.Models
+@page "/grower"
 
 @namespace OpenEug.TenTrees.Module.Grower
 @inherits ModuleBase

--- a/Client/Modules/Training/Index.razor
+++ b/Client/Modules/Training/Index.razor
@@ -1,6 +1,7 @@
 @using OpenEug.TenTrees.Module.Training.Services
 @using OpenEug.TenTrees.Module.Village.Services
 @using OpenEug.TenTrees.Models
+@page "/training"
 
 @namespace OpenEug.TenTrees.Module.Training
 @inherits ModuleBase

--- a/Client/Modules/Village/Index.razor
+++ b/Client/Modules/Village/Index.razor
@@ -1,4 +1,5 @@
 @using OpenEug.TenTrees.Module.Village.Services
+@page "/village"
 
 @namespace OpenEug.TenTrees.Module.Village
 @inherits ModuleBase


### PR DESCRIPTION
## Summary
Added explicit `@page` route directives to all module Index.razor components to enable direct navigation to each module.

## Changes
- **Assessment module**: Added `@page "/assessment"` directive
- **Enrollment module**: Added `@page "/enrollment"` directive
- **Grower module**: Added `@page "/grower"` directive
- **Training module**: Added `@page "/training"` directive
- **Village module**: Added `@page "/village"` directive

## Details
Each module's Index.razor component now includes an explicit `@page` directive that defines its route. This allows these components to be directly navigated to via their respective URLs, improving routing clarity and enabling proper Blazor routing resolution for module entry points.

https://claude.ai/code/session_0169iPVrWi9bjKPV1z23HGUs