### PR TITLE
Improve handling of returnurl in NavigateToIndex

### DIFF
--- a/Client/Modules/Grower/Status.razor
+++ b/Client/Modules/Grower/Status.razor
@@ -288,9 +288,16 @@ else
     private void NavigateToIndex()
     {
         if (PageState.QueryString.ContainsKey("returnurl"))
-            NavigationManager.NavigateTo(PageState.QueryString["returnurl"]);
-        else
-            NavigationManager.NavigateTo(NavigateUrl());
+        {
+            var returnUrl = PageState.QueryString["returnurl"];
+            if (!string.IsNullOrWhiteSpace(returnUrl))
+            {
+                NavigationManager.NavigateTo(Uri.UnescapeDataString(returnUrl));
+                return;
+            }
+        }
+
+        NavigationManager.NavigateTo(NavigateUrl());
     }
 
     private string GetStatusBadgeClass(GrowerStatus status)


### PR DESCRIPTION
Check for non-empty returnurl and unescape it before navigation. Falls back to default URL if returnurl is missing or empty, ensuring proper handling of encoded URLs and preventing navigation to invalid destinations.