### PR TITLE
Prevent duplicate initialization and expand cohort access roles

### DIFF
--- a/Client/Modules/Assessment/Edit.razor
+++ b/Client/Modules/Assessment/Edit.razor
@@ -364,6 +364,7 @@
     private string _modifiedby;
     private DateTime _modifiedon;
 
+    private bool _loaded = false;
     private bool _hasDraft = false;
     private const string DraftKey = "TenTrees_Assessment_Draft";
 
@@ -371,6 +372,9 @@
 
     protected override async Task OnParametersSetAsync()
     {
+        if (_loaded) return;
+        _loaded = true;
+
         try
         {
             var allGrowers = await GrowerService.GetActiveGrowersAsync();

--- a/Client/Modules/Enrollment/Index.razor
+++ b/Client/Modules/Enrollment/Index.razor
@@ -184,9 +184,13 @@
     private EnrollmentStatusSummary _summary;
     private string _statusFilter = "";
     private string _villageFilter = "";
+    private bool _loaded = false;
 
     protected override async Task OnParametersSetAsync()
     {
+        if (_loaded) return;
+        _loaded = true;
+
         try
         {
             await LoadVillagesAsync();

--- a/Client/Modules/Grower/Index.razor
+++ b/Client/Modules/Grower/Index.razor
@@ -131,7 +131,7 @@
                         <td>
                             <div class="d-flex gap-1">
                                 <ActionLink Action="Status" 
-                                           Parameters="@($"id={grower.GrowerId}&returnurl={Uri.EscapeDataString(GetReturnUrl())}")" 
+                                           Parameters="@($"id={grower.GrowerId}&returnurl={Uri.EscapeDataString(GetReturnUrl())}")"
                                            Text="@Localizer["Action.ManageStatus"]" 
                                            ResourceKey="ManageStatus" 
                                            Class="btn btn-sm btn-primary" />
@@ -188,10 +188,13 @@
     }
 
     // For mentors, pre-load only their assigned cohorts and restrict grower list accordingly.
-    // Admins see all cohorts (optionally filtered by village).
+    // Admins, Educators, and Project Managers see all cohorts (optionally filtered by village).
     private async Task LoadCohortsForMentorAsync()
     {
-        if (UserSecurity.IsAuthorized(PageState.User, RoleNames.Admin))
+        bool isMentorOnly = UserSecurity.IsAuthorized(PageState.User, "Mentor")
+            && !UserSecurity.IsAuthorized(PageState.User, RoleNames.Admin);
+
+        if (!isMentorOnly)
         {
             _cohorts = !string.IsNullOrEmpty(_villageFilter) && int.TryParse(_villageFilter, out var vid)
                 ? await CohortService.GetCohortsByVillageAsync(vid)


### PR DESCRIPTION
## Summary
This PR addresses initialization issues in Razor components and expands role-based access control for cohort management. The changes prevent duplicate async initialization calls and update authorization logic to include Educators and Project Managers alongside Admins.

## Key Changes

- **Prevent duplicate component initialization**: Added `_loaded` flag to `Assessment/Edit.razor` and `Enrollment/Index.razor` to prevent `OnParametersSetAsync()` from executing multiple times, which could cause redundant API calls and data inconsistencies.

- **Expand cohort access roles**: Updated `Grower/Index.razor` authorization logic to allow Educators and Project Managers (in addition to Admins) to view all cohorts. Mentors are now restricted to only their assigned cohorts, while other roles can see all cohorts with optional village filtering.

- **Minor formatting**: Removed trailing whitespace in `Grower/Index.razor`.

## Implementation Details

The initialization guard pattern uses a simple boolean flag that is set to `true` on first execution, preventing subsequent calls to `OnParametersSetAsync()` from re-executing the initialization logic. This is particularly important for async operations that fetch data from services.

The role-based access change introduces a `isMentorOnly` variable that explicitly checks if a user has the Mentor role without Admin privileges, providing clearer intent and more maintainable authorization logic.

https://claude.ai/code/session_016LZoA8izD878c7wrYrLxHA