### PR TITLE
Fix #92: Align Grower and Assessment controller routing with Oqtane

### DIFF
--- a/Server/Controllers/AssessmentController.cs
+++ b/Server/Controllers/AssessmentController.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Http;
 using Oqtane.Shared;
 using Oqtane.Enums;
 using Oqtane.Infrastructure;
+using Oqtane.Controllers;
 using OpenEug.TenTrees.Module.Assessment.Services;
 using OpenEug.TenTrees.Models;
 using System;
@@ -12,16 +13,14 @@ using System.Threading.Tasks;
 
 namespace OpenEug.TenTrees.Module.Assessment.Controllers
 {
-    [Route("api/[controller]")]
-    public class AssessmentController : Controller
+    [Route(ControllerRoutes.ApiRoute)]
+    public class AssessmentController : ModuleControllerBase
     {
         private readonly IAssessmentService _assessmentService;
-        private readonly ILogManager _logger;
 
-        public AssessmentController(IAssessmentService assessmentService, ILogManager logger)
+        public AssessmentController(IAssessmentService assessmentService, ILogManager logger, IHttpContextAccessor accessor) : base(logger, accessor)
         {
             _assessmentService = assessmentService;
-            _logger = logger;
         }
 
         [HttpGet]

--- a/Server/Controllers/GrowerController.cs
+++ b/Server/Controllers/GrowerController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using OpenEug.TenTrees.Module.Grower.Services;
 using OpenEug.TenTrees.Models;
+using Oqtane.Controllers;
 using Oqtane.Enums;
 using Oqtane.Infrastructure;
 using Oqtane.Shared;
@@ -12,16 +13,14 @@ using System.Threading.Tasks;
 
 namespace OpenEug.TenTrees.Module.Grower.Controllers
 {
-    [Route("api/[controller]")]
-    public class GrowerController : Controller
+    [Route(ControllerRoutes.ApiRoute)]
+    public class GrowerController : ModuleControllerBase
     {
         private readonly IGrowerService _growerService;
-        private readonly ILogManager _logger;
 
-        public GrowerController(IGrowerService growerService, ILogManager logger)
+        public GrowerController(IGrowerService growerService, ILogManager logger, IHttpContextAccessor accessor) : base(logger, accessor)
         {
             _growerService = growerService;
-            _logger = logger;
         }
 
         [HttpGet("{id}")]


### PR DESCRIPTION
## Summary

- **Fix #92**: `GrowerController` and `AssessmentController` used plain MVC routing (`[Route("api/[controller]")]`) and inherited from `Controller`, while all other controllers use `[Route(ControllerRoutes.ApiRoute)]` and `ModuleControllerBase`. The client services use `CreateApiUrl()` which generates Oqtane alias-prefixed URLs — these don't match the plain routes when the site has a non-empty alias, causing 404 errors.
- **Helps #102**: The Grower index page calls `GrowerService` for status summary and grower list. With broken routing, these calls failed, preventing the page from loading properly — which masked the working cohort dropdown.

### Issues reviewed but no code change needed

| Issue | Finding |
|-------|---------|
| **#87** (Village filter) | Filter logic is correctly wired with `@bind:after` and `ApplyFilters()`. VillageId is populated in the list view model query. May be stale or data-level. |
| **#78** (Clickable cards) | Already implemented — summary cards are `<button>` elements with `@onclick` handlers. |
| **#104** (Delete enrollment) | Already implemented — `ActionDialog` for delete exists in the enrollment table with a working `Delete` method. |

## Test plan

- [ ] Verify the Grower index page loads correctly (status summary cards + grower table)
- [ ] Verify the cohort filter dropdown on the Grower page populates with individual cohort names
- [ ] Verify the Assessment Edit form's grower dropdown populates (no more 404)
- [ ] Verify other controllers (Enrollment, Cohort, Village, Training) still work as before

https://claude.ai/code/session_01CUzdZkfoXy5X721wYrwHS7