### PR TITLE
Refactor assessment notes from single field to audit log

### DIFF
--- a/Client/Modules/Assessment/Edit.razor
+++ b/Client/Modules/Assessment/Edit.razor
@@ -151,9 +151,9 @@
                             <Label Class="col-sm-8 mb-0" For="needshelp_yes" ResourceKey="NeedsHelp">Do you need someone to help with this problem?</Label>
                             <div class="col-sm-4">
                                 <div class="btn-group w-100" role="group">
-                                    <input type="radio" class="btn-check" name="needshelp" id="needshelp_yes" autocomplete="off" checked="@(_needsHelp == true)" @onchange="@(() => _needsHelp = true)">
+                                    <input type="radio" class="btn-check" name="needshelp" id="needshelp_yes" autocomplete="off" checked="@(_needsHelp == true)" @onchange="@(() => OnNeedsHelpChanged(true))">
                                     <label class="btn btn-outline-danger" for="needshelp_yes">@Localizer["Yes"]</label>
-                                    <input type="radio" class="btn-check" name="needshelp" id="needshelp_no" autocomplete="off" checked="@(_needsHelp == false)" @onchange="@(() => _needsHelp = false)">
+                                    <input type="radio" class="btn-check" name="needshelp" id="needshelp_no" autocomplete="off" checked="@(_needsHelp == false)" @onchange="@(() => OnNeedsHelpChanged(false))">
                                     <label class="btn btn-outline-success" for="needshelp_no">@Localizer["No"]</label>
                                 </div>
                             </div>
@@ -272,15 +272,94 @@
                     </div>
                 </div>
 
-                <!-- Section 5: Notes -->
+                <!-- Section 5: Notes Log -->
                 <div class="card mb-3">
-                    <div class="card-header">
-                        <h5>@Localizer["Section.Notes"]</h5>
+                    <div class="card-header d-flex justify-content-between align-items-center">
+                        <h5 class="mb-0">Notes</h5>
+                        @if (_existingNotes.Count + _pendingNotes.Count > 0)
+                        {
+                            <span class="badge bg-secondary">@(_existingNotes.Count + _pendingNotes.Count)</span>
+                        }
                     </div>
                     <div class="card-body">
-                        <div class="row mb-2">
-                            <div class="col-sm-12">
-                                <textarea id="notes" class="form-control" @bind="@_notes" rows="4" placeholder="@Localizer["NotesPlaceholder"]"></textarea>
+                        @if (_existingNotes.Count == 0 && _pendingNotes.Count == 0)
+                        {
+                            <p class="text-muted small mb-3">No notes yet. Add the first observation below.</p>
+                        }
+                        else
+                        {
+                            <ul class="list-unstyled mb-3">
+                                @foreach (var note in _existingNotes.OrderBy(n => n.CreatedOn))
+                                {
+                                    <li class="mb-2 pb-2 border-bottom">
+                                        <div class="mb-1">
+                                            @if (note.NoteType == AssessmentNoteTypes.HomeVisit)
+                                            {
+                                                <span class="badge bg-warning text-dark me-1">Home Visit</span>
+                                            }
+                                            else
+                                            {
+                                                <span class="badge bg-secondary me-1">General</span>
+                                            }
+                                            <small class="text-muted">@note.CreatedOn.ToLocalTime().ToString("yyyy-MM-dd HH:mm") — @note.CreatedBy</small>
+                                        </div>
+                                        <div class="text-body" style="white-space: pre-wrap;">@note.Text</div>
+                                    </li>
+                                }
+                                @for (int i = 0; i < _pendingNotes.Count; i++)
+                                {
+                                    var note = _pendingNotes[i];
+                                    var pendingIndex = i;
+                                    <li class="mb-2 pb-2 border-bottom bg-light px-2 py-2 rounded">
+                                        <div class="d-flex justify-content-between align-items-start mb-1">
+                                            <span>
+                                                @if (note.NoteType == AssessmentNoteTypes.HomeVisit)
+                                                {
+                                                    <span class="badge bg-warning text-dark me-1">Home Visit</span>
+                                                }
+                                                else
+                                                {
+                                                    <span class="badge bg-secondary me-1">General</span>
+                                                }
+                                                <small class="text-muted">Pending — saved when you click Save</small>
+                                            </span>
+                                            <button type="button" class="btn btn-sm btn-link text-danger p-0"
+                                                    @onclick="@(() => RemovePendingNote(pendingIndex))"
+                                                    aria-label="Remove pending note">
+                                                <span class="oi oi-x" aria-hidden="true"></span>
+                                            </button>
+                                        </div>
+                                        <div class="text-body" style="white-space: pre-wrap;">@note.Text</div>
+                                    </li>
+                                }
+                            </ul>
+                        }
+
+                        @if (_needsHelp)
+                        {
+                            <div class="alert alert-warning py-2 small mb-2" role="status">
+                                <span class="oi oi-warning me-1" aria-hidden="true"></span>
+                                This assessment is flagged as needing help. Please describe the issue below as a Home Visit note.
+                            </div>
+                        }
+
+                        <div class="mb-2">
+                            <label for="newNoteText" class="form-label mb-1">Add a note</label>
+                            <textarea id="newNoteText" class="form-control mb-2" rows="3"
+                                      placeholder="Observation, action taken, follow-up…"
+                                      @bind="_newNoteText"></textarea>
+                            <div class="d-flex align-items-center gap-2 flex-wrap">
+                                <label for="newNoteType" class="visually-hidden">Note type</label>
+                                <select id="newNoteType" class="form-select form-select-sm w-auto" @bind="_newNoteType">
+                                    <option value="@AssessmentNoteTypes.General">General</option>
+                                    <option value="@AssessmentNoteTypes.HomeVisit">Home Visit</option>
+                                </select>
+                                <button type="button" class="btn btn-sm btn-outline-primary"
+                                        @onclick="AddPendingNote"
+                                        disabled="@(string.IsNullOrWhiteSpace(_newNoteText))">
+                                    <span class="oi oi-plus me-1" aria-hidden="true"></span>Add Note
+                                </button>
+                                <small class="text-muted ms-auto">Notes are appended to the running log and cannot be edited once saved.</small>
                             </div>
                         </div>
                     </div>
@@ -355,8 +434,11 @@
     private bool _isGardenDesignedToCaptureWater;
     private bool _isUsingGreywater;
 
-    // Notes
-    private string _notes;
+    // Notes log
+    private List<Models.AssessmentNote> _existingNotes = new();
+    private List<Models.AssessmentNote> _pendingNotes = new();
+    private string _newNoteText = string.Empty;
+    private string _newNoteType = AssessmentNoteTypes.General;
 
     // Audit fields
     private string _createdby;
@@ -366,7 +448,13 @@
 
     private bool _loaded = false;
     private bool _hasDraft = false;
-    private const string DraftKey = "TenTrees_Assessment_Draft";
+    private const string DraftKey = "TenTrees_Assessment_Draft_V2";
+
+    private class AssessmentDraft
+    {
+        public Models.Assessment Assessment { get; set; }
+        public List<Models.AssessmentNote> PendingNotes { get; set; } = new();
+    }
 
     private int SurvivalRate => _treesPlanted > 0 ? (_treesAlive * 100 / _treesPlanted) : 0;
 
@@ -433,7 +521,7 @@
                         _isGardenDesignedToCaptureWater = assessment.IsGardenDesignedToCaptureWater;
                         _isUsingGreywater = assessment.IsUsingGreywater;
 
-                        _notes = assessment.Notes;
+                        _existingNotes = await AssessmentService.GetNotesByAssessmentAsync(_id) ?? new List<Models.AssessmentNote>();
 
                         _createdby = assessment.CreatedBy;
                         _createdon = assessment.CreatedOn;
@@ -474,30 +562,33 @@
     {
         try
         {
-            var draft = new Models.Assessment
+            var draft = new AssessmentDraft
             {
-                GrowerId = _growerId,
-                Name = _name,
-                AssessmentDate = _assessmentDate,
-                TreesPlanted = _treesPlanted,
-                TreesAlive = _treesAlive,
-                DeceasedTreeTypes = !string.IsNullOrEmpty(_deceasedTreeTypesOther) ? _deceasedTreeTypesOther : _deceasedTreeTypes,
-                HasBrokenBranches = _hasBrokenBranches,
-                HasYellowLeaves = _hasYellowLeaves,
-                HasLosingLeaves = _hasLosingLeaves,
-                HasLookDry = _hasLookDry,
-                HasPests = _hasPests,
-                NeedsHelp = _needsHelp,
-                TreesLookHealthy = _treesLookHealthy,
-                HasChemicalFertilizers = _hasChemicalFertilizers,
-                HasPesticides = _hasPesticides,
-                IsMulched = _isMulched,
-                IsMakingCompost = _isMakingCompost,
-                IsCollectingWater = _isCollectingWater,
-                HasLeakyTaps = _hasLeakyTaps,
-                IsGardenDesignedToCaptureWater = _isGardenDesignedToCaptureWater,
-                IsUsingGreywater = _isUsingGreywater,
-                Notes = _notes
+                Assessment = new Models.Assessment
+                {
+                    GrowerId = _growerId,
+                    Name = _name,
+                    AssessmentDate = _assessmentDate,
+                    TreesPlanted = _treesPlanted,
+                    TreesAlive = _treesAlive,
+                    DeceasedTreeTypes = !string.IsNullOrEmpty(_deceasedTreeTypesOther) ? _deceasedTreeTypesOther : _deceasedTreeTypes,
+                    HasBrokenBranches = _hasBrokenBranches,
+                    HasYellowLeaves = _hasYellowLeaves,
+                    HasLosingLeaves = _hasLosingLeaves,
+                    HasLookDry = _hasLookDry,
+                    HasPests = _hasPests,
+                    NeedsHelp = _needsHelp,
+                    TreesLookHealthy = _treesLookHealthy,
+                    HasChemicalFertilizers = _hasChemicalFertilizers,
+                    HasPesticides = _hasPesticides,
+                    IsMulched = _isMulched,
+                    IsMakingCompost = _isMakingCompost,
+                    IsCollectingWater = _isCollectingWater,
+                    HasLeakyTaps = _hasLeakyTaps,
+                    IsGardenDesignedToCaptureWater = _isGardenDesignedToCaptureWater,
+                    IsUsingGreywater = _isUsingGreywater
+                },
+                PendingNotes = _pendingNotes
             };
 
             var json = System.Text.Json.JsonSerializer.Serialize(draft);
@@ -519,42 +610,44 @@
             var json = await JSRuntime.InvokeAsync<string>("localStorage.getItem", DraftKey);
             if (!string.IsNullOrEmpty(json))
             {
-                var draft = System.Text.Json.JsonSerializer.Deserialize<Models.Assessment>(json);
-                if (draft != null)
+                var draft = System.Text.Json.JsonSerializer.Deserialize<AssessmentDraft>(json);
+                if (draft?.Assessment != null)
                 {
-                    _growerId = draft.GrowerId;
-                    _name = draft.Name;
-                    _assessmentDate = draft.AssessmentDate;
-                    _treesPlanted = draft.TreesPlanted;
-                    _treesAlive = draft.TreesAlive;
+                    var a = draft.Assessment;
+                    _growerId = a.GrowerId;
+                    _name = a.Name;
+                    _assessmentDate = a.AssessmentDate;
+                    _treesPlanted = a.TreesPlanted;
+                    _treesAlive = a.TreesAlive;
 
-                    if (!string.IsNullOrEmpty(draft.DeceasedTreeTypes))
+                    if (!string.IsNullOrEmpty(a.DeceasedTreeTypes))
                     {
-                        if (_availableTreeTypes != null && _availableTreeTypes.Any(t => t.Name == draft.DeceasedTreeTypes))
+                        if (_availableTreeTypes != null && _availableTreeTypes.Any(t => t.Name == a.DeceasedTreeTypes))
                         {
-                            _deceasedTreeTypes = draft.DeceasedTreeTypes;
+                            _deceasedTreeTypes = a.DeceasedTreeTypes;
                         }
                         else
                         {
-                            _deceasedTreeTypesOther = draft.DeceasedTreeTypes;
+                            _deceasedTreeTypesOther = a.DeceasedTreeTypes;
                         }
                     }
-                    _hasBrokenBranches = draft.HasBrokenBranches;
-                    _hasYellowLeaves = draft.HasYellowLeaves;
-                    _hasLosingLeaves = draft.HasLosingLeaves;
-                    _hasLookDry = draft.HasLookDry;
-                    _hasPests = draft.HasPests;
-                    _needsHelp = draft.NeedsHelp;
-                    _treesLookHealthy = draft.TreesLookHealthy;
-                    _hasChemicalFertilizers = draft.HasChemicalFertilizers;
-                    _hasPesticides = draft.HasPesticides;
-                    _isMulched = draft.IsMulched;
-                    _isMakingCompost = draft.IsMakingCompost;
-                    _isCollectingWater = draft.IsCollectingWater;
-                    _hasLeakyTaps = draft.HasLeakyTaps;
-                    _isGardenDesignedToCaptureWater = draft.IsGardenDesignedToCaptureWater;
-                    _isUsingGreywater = draft.IsUsingGreywater;
-                    _notes = draft.Notes;
+                    _hasBrokenBranches = a.HasBrokenBranches;
+                    _hasYellowLeaves = a.HasYellowLeaves;
+                    _hasLosingLeaves = a.HasLosingLeaves;
+                    _hasLookDry = a.HasLookDry;
+                    _hasPests = a.HasPests;
+                    _needsHelp = a.NeedsHelp;
+                    _treesLookHealthy = a.TreesLookHealthy;
+                    _hasChemicalFertilizers = a.HasChemicalFertilizers;
+                    _hasPesticides = a.HasPesticides;
+                    _isMulched = a.IsMulched;
+                    _isMakingCompost = a.IsMakingCompost;
+                    _isCollectingWater = a.IsCollectingWater;
+                    _hasLeakyTaps = a.HasLeakyTaps;
+                    _isGardenDesignedToCaptureWater = a.IsGardenDesignedToCaptureWater;
+                    _isUsingGreywater = a.IsUsingGreywater;
+
+                    _pendingNotes = draft.PendingNotes ?? new List<Models.AssessmentNote>();
 
                     AddModuleMessage(Localizer["Message.DraftLoaded"], MessageType.Success);
                 }
@@ -618,13 +711,14 @@
                     assessment.IsGardenDesignedToCaptureWater = _isGardenDesignedToCaptureWater;
                     assessment.IsUsingGreywater = _isUsingGreywater;
 
-                    assessment.Notes = _notes;
-                    
                     assessment.SubmittedBy = PageState.User.Username;
                     assessment.EnteredByAdmin = UserSecurity.IsAuthorized(PageState.User, RoleNames.Admin);
-                    
+
                     assessment = await AssessmentService.AddAssessmentAsync(assessment);
                     await logger.LogInformation("Assessment Added {Assessment}", assessment);
+
+                    await PersistPendingNotesAsync(assessment.AssessmentId);
+
                     await JSRuntime.InvokeVoidAsync("localStorage.removeItem", DraftKey);
                     AddModuleMessage(Localizer["Message.SaveSuccess"], MessageType.Success);
                     NavigationManager.NavigateTo(NavigateUrl());
@@ -657,10 +751,11 @@
                     assessment.IsGardenDesignedToCaptureWater = _isGardenDesignedToCaptureWater;
                     assessment.IsUsingGreywater = _isUsingGreywater;
 
-                    assessment.Notes = _notes;
-
                     await AssessmentService.UpdateAssessmentAsync(assessment);
                     await logger.LogInformation("Assessment Updated {Assessment}", assessment);
+
+                    await PersistPendingNotesAsync(assessment.AssessmentId);
+
                     await JSRuntime.InvokeVoidAsync("localStorage.removeItem", DraftKey);
                     AddModuleMessage(Localizer["Message.UpdateSuccess"], MessageType.Success);
                     NavigationManager.NavigateTo(NavigateUrl());
@@ -691,5 +786,64 @@
             await logger.LogError(ex, "Error Deleting Assessment {AssessmentId} {Error}", _id, ex.Message);
             AddModuleMessage(Localizer["Message.DeleteError"], MessageType.Error);
         }
+    }
+
+    private void OnNeedsHelpChanged(bool needsHelp)
+    {
+        _needsHelp = needsHelp;
+        if (needsHelp && string.IsNullOrWhiteSpace(_newNoteText))
+        {
+            // Pre-select the Home Visit note type so the composer is ready
+            // for the required follow-up explaining the issue.
+            _newNoteType = AssessmentNoteTypes.HomeVisit;
+        }
+    }
+
+    private void AddPendingNote()
+    {
+        if (string.IsNullOrWhiteSpace(_newNoteText))
+        {
+            return;
+        }
+
+        var type = _newNoteType == AssessmentNoteTypes.HomeVisit
+            ? AssessmentNoteTypes.HomeVisit
+            : AssessmentNoteTypes.General;
+
+        _pendingNotes.Add(new Models.AssessmentNote
+        {
+            NoteType = type,
+            Text = _newNoteText.Trim()
+        });
+
+        _newNoteText = string.Empty;
+        _newNoteType = AssessmentNoteTypes.General;
+    }
+
+    private void RemovePendingNote(int index)
+    {
+        if (index < 0 || index >= _pendingNotes.Count) return;
+        _pendingNotes.RemoveAt(index);
+    }
+
+    private async Task PersistPendingNotesAsync(int assessmentId)
+    {
+        if (_pendingNotes.Count == 0) return;
+
+        foreach (var note in _pendingNotes)
+        {
+            note.AssessmentId = assessmentId;
+            try
+            {
+                await AssessmentService.AddNoteAsync(note);
+            }
+            catch (Exception ex)
+            {
+                await logger.LogError(ex, "Error Saving Assessment Note {AssessmentId} {Error}", assessmentId, ex.Message);
+                AddModuleMessage("One or more notes could not be saved. Please retry.", MessageType.Error);
+            }
+        }
+
+        _pendingNotes.Clear();
     }
 }

--- a/Client/Modules/Assessment/Edit.razor
+++ b/Client/Modules/Assessment/Edit.razor
@@ -275,7 +275,7 @@
                 <!-- Section 5: Notes Log -->
                 <div class="card mb-3">
                     <div class="card-header d-flex justify-content-between align-items-center">
-                        <h5 class="mb-0">Notes</h5>
+                        <h5 class="mb-0">@Localizer["Section.Notes"]</h5>
                         @if (_existingNotes.Count + _pendingNotes.Count > 0)
                         {
                             <span class="badge bg-secondary">@(_existingNotes.Count + _pendingNotes.Count)</span>
@@ -284,7 +284,7 @@
                     <div class="card-body">
                         @if (_existingNotes.Count == 0 && _pendingNotes.Count == 0)
                         {
-                            <p class="text-muted small mb-3">No notes yet. Add the first observation below.</p>
+                            <p class="text-muted small mb-3">@Localizer["Notes.Empty"]</p>
                         }
                         else
                         {
@@ -295,11 +295,11 @@
                                         <div class="mb-1">
                                             @if (note.NoteType == AssessmentNoteTypes.HomeVisit)
                                             {
-                                                <span class="badge bg-warning text-dark me-1">Home Visit</span>
+                                                <span class="badge bg-warning text-dark me-1">@Localizer["Note.TypeHomeVisit"]</span>
                                             }
                                             else
                                             {
-                                                <span class="badge bg-secondary me-1">General</span>
+                                                <span class="badge bg-secondary me-1">@Localizer["Note.TypeGeneral"]</span>
                                             }
                                             <small class="text-muted">@note.CreatedOn.ToLocalTime().ToString("yyyy-MM-dd HH:mm") — @note.CreatedBy</small>
                                         </div>
@@ -315,17 +315,17 @@
                                             <span>
                                                 @if (note.NoteType == AssessmentNoteTypes.HomeVisit)
                                                 {
-                                                    <span class="badge bg-warning text-dark me-1">Home Visit</span>
+                                                    <span class="badge bg-warning text-dark me-1">@Localizer["Note.TypeHomeVisit"]</span>
                                                 }
                                                 else
                                                 {
-                                                    <span class="badge bg-secondary me-1">General</span>
+                                                    <span class="badge bg-secondary me-1">@Localizer["Note.TypeGeneral"]</span>
                                                 }
-                                                <small class="text-muted">Pending — saved when you click Save</small>
+                                                <small class="text-muted">@Localizer["Note.PendingLabel"]</small>
                                             </span>
                                             <button type="button" class="btn btn-sm btn-link text-danger p-0"
                                                     @onclick="@(() => RemovePendingNote(pendingIndex))"
-                                                    aria-label="Remove pending note">
+                                                    aria-label="@Localizer["Note.RemoveAriaLabel"]">
                                                 <span class="oi oi-x" aria-hidden="true"></span>
                                             </button>
                                         </div>
@@ -339,27 +339,27 @@
                         {
                             <div class="alert alert-warning py-2 small mb-2" role="status">
                                 <span class="oi oi-warning me-1" aria-hidden="true"></span>
-                                This assessment is flagged as needing help. Please describe the issue below as a Home Visit note.
+                                @Localizer["Note.NeedsHelpAlert"]
                             </div>
                         }
 
                         <div class="mb-2">
-                            <label for="newNoteText" class="form-label mb-1">Add a note</label>
+                            <label for="newNoteText" class="form-label mb-1">@Localizer["Note.AddLabel"]</label>
                             <textarea id="newNoteText" class="form-control mb-2" rows="3"
-                                      placeholder="Observation, action taken, follow-up…"
+                                      placeholder="@Localizer["Note.Placeholder"]"
                                       @bind="_newNoteText"></textarea>
                             <div class="d-flex align-items-center gap-2 flex-wrap">
-                                <label for="newNoteType" class="visually-hidden">Note type</label>
+                                <label for="newNoteType" class="visually-hidden">@Localizer["Note.TypeLabel"]</label>
                                 <select id="newNoteType" class="form-select form-select-sm w-auto" @bind="_newNoteType">
-                                    <option value="@AssessmentNoteTypes.General">General</option>
-                                    <option value="@AssessmentNoteTypes.HomeVisit">Home Visit</option>
+                                    <option value="@AssessmentNoteTypes.General">@Localizer["Note.TypeGeneral"]</option>
+                                    <option value="@AssessmentNoteTypes.HomeVisit">@Localizer["Note.TypeHomeVisit"]</option>
                                 </select>
                                 <button type="button" class="btn btn-sm btn-outline-primary"
                                         @onclick="AddPendingNote"
                                         disabled="@(string.IsNullOrWhiteSpace(_newNoteText))">
-                                    <span class="oi oi-plus me-1" aria-hidden="true"></span>Add Note
+                                    <span class="oi oi-plus me-1" aria-hidden="true"></span>@Localizer["Note.AddButton"]
                                 </button>
-                                <small class="text-muted ms-auto">Notes are appended to the running log and cannot be edited once saved.</small>
+                                <small class="text-muted ms-auto">@Localizer["Note.ImmutableHint"]</small>
                             </div>
                         </div>
                     </div>
@@ -853,7 +853,7 @@
 
         if (_pendingNotes.Count > 0)
         {
-            AddModuleMessage("One or more notes could not be saved. Please retry.", MessageType.Error);
+            AddModuleMessage(Localizer["Message.NoteSaveError"], MessageType.Error);
             return false;
         }
 

--- a/Client/Modules/Assessment/Edit.razor
+++ b/Client/Modules/Assessment/Edit.razor
@@ -717,11 +717,12 @@
                     assessment = await AssessmentService.AddAssessmentAsync(assessment);
                     await logger.LogInformation("Assessment Added {Assessment}", assessment);
 
-                    await PersistPendingNotesAsync(assessment.AssessmentId);
-
-                    await JSRuntime.InvokeVoidAsync("localStorage.removeItem", DraftKey);
-                    AddModuleMessage(Localizer["Message.SaveSuccess"], MessageType.Success);
-                    NavigationManager.NavigateTo(NavigateUrl());
+                    if (await PersistPendingNotesAsync(assessment.AssessmentId))
+                    {
+                        await JSRuntime.InvokeVoidAsync("localStorage.removeItem", DraftKey);
+                        AddModuleMessage(Localizer["Message.SaveSuccess"], MessageType.Success);
+                        NavigationManager.NavigateTo(NavigateUrl());
+                    }
                 }
                 else
                 {
@@ -754,11 +755,12 @@
                     await AssessmentService.UpdateAssessmentAsync(assessment);
                     await logger.LogInformation("Assessment Updated {Assessment}", assessment);
 
-                    await PersistPendingNotesAsync(assessment.AssessmentId);
-
-                    await JSRuntime.InvokeVoidAsync("localStorage.removeItem", DraftKey);
-                    AddModuleMessage(Localizer["Message.UpdateSuccess"], MessageType.Success);
-                    NavigationManager.NavigateTo(NavigateUrl());
+                    if (await PersistPendingNotesAsync(assessment.AssessmentId))
+                    {
+                        await JSRuntime.InvokeVoidAsync("localStorage.removeItem", DraftKey);
+                        AddModuleMessage(Localizer["Message.UpdateSuccess"], MessageType.Success);
+                        NavigationManager.NavigateTo(NavigateUrl());
+                    }
                 }
             }
             else
@@ -826,9 +828,11 @@
         _pendingNotes.RemoveAt(index);
     }
 
-    private async Task PersistPendingNotesAsync(int assessmentId)
+    private async Task<bool> PersistPendingNotesAsync(int assessmentId)
     {
-        if (_pendingNotes.Count == 0) return;
+        if (_pendingNotes.Count == 0) return true;
+
+        var failedNotes = new List<Models.AssessmentNote>();
 
         foreach (var note in _pendingNotes)
         {
@@ -840,10 +844,19 @@
             catch (Exception ex)
             {
                 await logger.LogError(ex, "Error Saving Assessment Note {AssessmentId} {Error}", assessmentId, ex.Message);
-                AddModuleMessage("One or more notes could not be saved. Please retry.", MessageType.Error);
+                failedNotes.Add(note);
             }
         }
 
         _pendingNotes.Clear();
+        _pendingNotes.AddRange(failedNotes);
+
+        if (_pendingNotes.Count > 0)
+        {
+            AddModuleMessage("One or more notes could not be saved. Please retry.", MessageType.Error);
+            return false;
+        }
+
+        return true;
     }
 }

--- a/Client/Modules/Grower/Status.razor
+++ b/Client/Modules/Grower/Status.razor
@@ -287,7 +287,7 @@ else
         <!-- Assessment Notes Log -->
         <div class="card mb-3">
             <div class="card-header d-flex justify-content-between align-items-center">
-                <h5 class="mb-0"><i class="bi bi-journal-text me-2" aria-hidden="true"></i>Notes &amp; Home Visits</h5>
+                <h5 class="mb-0"><i class="bi bi-journal-text me-2" aria-hidden="true"></i>@Localizer["Section.Notes"]</h5>
                 @if (_assessmentNotes.Count > 0)
                 {
                     <span class="badge bg-secondary">@_assessmentNotes.Count</span>
@@ -296,7 +296,7 @@ else
             <div class="card-body">
                 @if (_assessmentNotes.Count == 0)
                 {
-                    <p class="text-muted mb-0">No notes recorded for this grower yet.</p>
+                    <p class="text-muted mb-0">@Localizer["Notes.Empty"]</p>
                 }
                 else
                 {
@@ -307,11 +307,11 @@ else
                                 <div class="mb-1">
                                     @if (note.NoteType == AssessmentNoteTypes.HomeVisit)
                                     {
-                                        <span class="badge bg-warning text-dark me-1">Home Visit</span>
+                                        <span class="badge bg-warning text-dark me-1">@Localizer["Note.TypeHomeVisit"]</span>
                                     }
                                     else
                                     {
-                                        <span class="badge bg-secondary me-1">General</span>
+                                        <span class="badge bg-secondary me-1">@Localizer["Note.TypeGeneral"]</span>
                                     }
                                     <small class="text-muted">@note.CreatedOn.ToLocalTime().ToString("yyyy-MM-dd HH:mm") — @note.CreatedBy</small>
                                 </div>

--- a/Client/Modules/Grower/Status.razor
+++ b/Client/Modules/Grower/Status.razor
@@ -251,7 +251,24 @@ else
                                                 <span class="badge bg-success">@Localizer["Label.No"]</span>
                                             }
                                         </td>
-                                        <td>@(string.IsNullOrWhiteSpace(assessment.Notes) ? "-" : assessment.Notes)</td>
+                                        <td>
+                                            @{
+                                                var noteCount = _assessmentNotes.Count(n => n.AssessmentId == assessment.AssessmentId);
+                                                var homeVisitCount = _assessmentNotes.Count(n => n.AssessmentId == assessment.AssessmentId && n.NoteType == AssessmentNoteTypes.HomeVisit);
+                                            }
+                                            @if (noteCount == 0)
+                                            {
+                                                <span class="text-muted">-</span>
+                                            }
+                                            else
+                                            {
+                                                <span class="badge bg-secondary me-1" title="Total notes">@noteCount</span>
+                                                @if (homeVisitCount > 0)
+                                                {
+                                                    <span class="badge bg-warning text-dark" title="Home visit notes">@homeVisitCount HV</span>
+                                                }
+                                            }
+                                        </td>
                                         <td>
                                             <a href="/Assessment" class="btn btn-sm btn-outline-secondary" title="@Localizer["Action.ViewRecord"]">
                                                 <i class="bi bi-box-arrow-up-right" aria-hidden="true"></i>
@@ -263,6 +280,45 @@ else
                             </tbody>
                         </table>
                     </div>
+                }
+            </div>
+        </div>
+
+        <!-- Assessment Notes Log -->
+        <div class="card mb-3">
+            <div class="card-header d-flex justify-content-between align-items-center">
+                <h5 class="mb-0"><i class="bi bi-journal-text me-2" aria-hidden="true"></i>Notes &amp; Home Visits</h5>
+                @if (_assessmentNotes.Count > 0)
+                {
+                    <span class="badge bg-secondary">@_assessmentNotes.Count</span>
+                }
+            </div>
+            <div class="card-body">
+                @if (_assessmentNotes.Count == 0)
+                {
+                    <p class="text-muted mb-0">No notes recorded for this grower yet.</p>
+                }
+                else
+                {
+                    <ul class="list-unstyled mb-0">
+                        @foreach (var note in _assessmentNotes)
+                        {
+                            <li class="mb-2 pb-2 border-bottom">
+                                <div class="mb-1">
+                                    @if (note.NoteType == AssessmentNoteTypes.HomeVisit)
+                                    {
+                                        <span class="badge bg-warning text-dark me-1">Home Visit</span>
+                                    }
+                                    else
+                                    {
+                                        <span class="badge bg-secondary me-1">General</span>
+                                    }
+                                    <small class="text-muted">@note.CreatedOn.ToLocalTime().ToString("yyyy-MM-dd HH:mm") — @note.CreatedBy</small>
+                                </div>
+                                <div class="text-body" style="white-space: pre-wrap;">@note.Text</div>
+                            </li>
+                        }
+                    </ul>
                 }
             </div>
         </div>
@@ -283,6 +339,7 @@ else
     private List<Models.Cohort> _growerCohorts = new();
     private List<Models.Cohort> _availableCohorts = new();
     private List<Models.Assessment> _assessments = new();
+    private List<Models.AssessmentNote> _assessmentNotes = new();
     private int _cohortToAdd;
     private int _pendingRemoveCohortId;
     private DateTime _exitDate = DateTime.Today;
@@ -425,6 +482,11 @@ else
         var all = await AssessmentService.GetAssessmentsByGrowerAsync(_grower.GrowerId);
         _assessments = (all ?? new List<Models.Assessment>())
             .OrderByDescending(a => a.AssessmentDate)
+            .ToList();
+
+        var notes = await AssessmentService.GetNotesByGrowerAsync(_grower.GrowerId);
+        _assessmentNotes = (notes ?? new List<Models.AssessmentNote>())
+            .OrderByDescending(n => n.CreatedOn)
             .ToList();
     }
 

--- a/Client/Resources/OpenEug.TenTrees.Module.Assessment/Edit.resx
+++ b/Client/Resources/OpenEug.TenTrees.Module.Assessment/Edit.resx
@@ -87,6 +87,39 @@
   <data name="Section.Notes" xml:space="preserve">
     <value>Notes</value>
   </data>
+  <data name="Notes.Empty" xml:space="preserve">
+    <value>No notes yet. Add the first observation below.</value>
+  </data>
+  <data name="Note.TypeGeneral" xml:space="preserve">
+    <value>General</value>
+  </data>
+  <data name="Note.TypeHomeVisit" xml:space="preserve">
+    <value>Home Visit</value>
+  </data>
+  <data name="Note.PendingLabel" xml:space="preserve">
+    <value>Pending — saved when you click Save</value>
+  </data>
+  <data name="Note.RemoveAriaLabel" xml:space="preserve">
+    <value>Remove pending note</value>
+  </data>
+  <data name="Note.NeedsHelpAlert" xml:space="preserve">
+    <value>This assessment is flagged as needing help. Please describe the issue below as a Home Visit note.</value>
+  </data>
+  <data name="Note.AddLabel" xml:space="preserve">
+    <value>Add a note</value>
+  </data>
+  <data name="Note.TypeLabel" xml:space="preserve">
+    <value>Note type</value>
+  </data>
+  <data name="Note.Placeholder" xml:space="preserve">
+    <value>Observation, action taken, follow-up…</value>
+  </data>
+  <data name="Note.AddButton" xml:space="preserve">
+    <value>Add Note</value>
+  </data>
+  <data name="Note.ImmutableHint" xml:space="preserve">
+    <value>Notes are appended to the running log and cannot be edited once saved.</value>
+  </data>
   <data name="NotesPlaceholder" xml:space="preserve">
     <value>Enter any additional notes here...</value>
   </data>
@@ -146,5 +179,8 @@
   </data>
   <data name="Message.DeleteError" xml:space="preserve">
     <value>Error deleting assessment.</value>
+  </data>
+  <data name="Message.NoteSaveError" xml:space="preserve">
+    <value>One or more notes could not be saved. Please retry.</value>
   </data>
 </root>

--- a/Client/Resources/OpenEug.TenTrees.Module.Assessment/Edit.ts-ZA.resx
+++ b/Client/Resources/OpenEug.TenTrees.Module.Assessment/Edit.ts-ZA.resx
@@ -87,6 +87,39 @@
   <data name="Section.Notes" xml:space="preserve">
     <value>[XS] Notes</value>
   </data>
+  <data name="Notes.Empty" xml:space="preserve">
+    <value>[XS] No notes yet. Add the first observation below.</value>
+  </data>
+  <data name="Note.TypeGeneral" xml:space="preserve">
+    <value>[XS] General</value>
+  </data>
+  <data name="Note.TypeHomeVisit" xml:space="preserve">
+    <value>[XS] Home Visit</value>
+  </data>
+  <data name="Note.PendingLabel" xml:space="preserve">
+    <value>[XS] Pending — saved when you click Save</value>
+  </data>
+  <data name="Note.RemoveAriaLabel" xml:space="preserve">
+    <value>[XS] Remove pending note</value>
+  </data>
+  <data name="Note.NeedsHelpAlert" xml:space="preserve">
+    <value>[XS] This assessment is flagged as needing help. Please describe the issue below as a Home Visit note.</value>
+  </data>
+  <data name="Note.AddLabel" xml:space="preserve">
+    <value>[XS] Add a note</value>
+  </data>
+  <data name="Note.TypeLabel" xml:space="preserve">
+    <value>[XS] Note type</value>
+  </data>
+  <data name="Note.Placeholder" xml:space="preserve">
+    <value>[XS] Observation, action taken, follow-up…</value>
+  </data>
+  <data name="Note.AddButton" xml:space="preserve">
+    <value>[XS] Add Note</value>
+  </data>
+  <data name="Note.ImmutableHint" xml:space="preserve">
+    <value>[XS] Notes are appended to the running log and cannot be edited once saved.</value>
+  </data>
   <data name="NotesPlaceholder" xml:space="preserve">
     <value>[XS] Enter any additional notes here...</value>
   </data>
@@ -146,5 +179,8 @@
   </data>
   <data name="Message.DeleteError" xml:space="preserve">
     <value>[XS] Error deleting assessment.</value>
+  </data>
+  <data name="Message.NoteSaveError" xml:space="preserve">
+    <value>[XS] One or more notes could not be saved. Please retry.</value>
   </data>
 </root>

--- a/Client/Resources/OpenEug.TenTrees.Module.Grower/Status.resx
+++ b/Client/Resources/OpenEug.TenTrees.Module.Grower/Status.resx
@@ -138,4 +138,16 @@
   <data name="Action.ViewRecord" xml:space="preserve">
     <value>View Full Record</value>
   </data>
+  <data name="Section.Notes" xml:space="preserve">
+    <value>Notes &amp; Home Visits</value>
+  </data>
+  <data name="Notes.Empty" xml:space="preserve">
+    <value>No notes recorded for this grower yet.</value>
+  </data>
+  <data name="Note.TypeGeneral" xml:space="preserve">
+    <value>General</value>
+  </data>
+  <data name="Note.TypeHomeVisit" xml:space="preserve">
+    <value>Home Visit</value>
+  </data>
 </root>

--- a/Client/Resources/OpenEug.TenTrees.Module.Grower/Status.ts-ZA.resx
+++ b/Client/Resources/OpenEug.TenTrees.Module.Grower/Status.ts-ZA.resx
@@ -50,4 +50,16 @@
   <data name="Action.ViewRecord" xml:space="preserve">
     <value>[XS] View Full Record</value>
   </data>
+  <data name="Section.Notes" xml:space="preserve">
+    <value>[XS] Notes &amp; Home Visits</value>
+  </data>
+  <data name="Notes.Empty" xml:space="preserve">
+    <value>[XS] No notes recorded for this grower yet.</value>
+  </data>
+  <data name="Note.TypeGeneral" xml:space="preserve">
+    <value>[XS] General</value>
+  </data>
+  <data name="Note.TypeHomeVisit" xml:space="preserve">
+    <value>[XS] Home Visit</value>
+  </data>
 </root>

--- a/Client/Services/AssessmentService.cs
+++ b/Client/Services/AssessmentService.cs
@@ -73,5 +73,20 @@ namespace OpenEug.TenTrees.Module.Assessment.Services
             if (queryParams.Count > 0) url += "?" + string.Join("&", queryParams);
             return await GetJsonAsync<List<AssessmentListDto>>(url, new List<AssessmentListDto>());
         }
+
+        public async Task<List<Models.AssessmentNote>> GetNotesByAssessmentAsync(int assessmentId)
+        {
+            return await GetJsonAsync<List<Models.AssessmentNote>>($"{ApiUrl}/{assessmentId}/notes", new List<Models.AssessmentNote>());
+        }
+
+        public async Task<List<Models.AssessmentNote>> GetNotesByGrowerAsync(int growerId)
+        {
+            return await GetJsonAsync<List<Models.AssessmentNote>>($"{ApiUrl}/grower/{growerId}/notes", new List<Models.AssessmentNote>());
+        }
+
+        public async Task<Models.AssessmentNote> AddNoteAsync(Models.AssessmentNote note)
+        {
+            return await PostJsonAsync<Models.AssessmentNote>($"{ApiUrl}/{note.AssessmentId}/notes", note);
+        }
     }
 }

--- a/Server/Controllers/AssessmentController.cs
+++ b/Server/Controllers/AssessmentController.cs
@@ -181,5 +181,77 @@ namespace OpenEug.TenTrees.Module.Assessment.Controllers
                 return StatusCode(StatusCodes.Status500InternalServerError);
             }
         }
+
+        [HttpGet("{id}/notes")]
+        [Authorize]
+        public async Task<ActionResult<IEnumerable<Models.AssessmentNote>>> GetNotes(int id)
+        {
+            try
+            {
+                var notes = await _assessmentService.GetNotesByAssessmentAsync(id);
+                return Ok(notes);
+            }
+            catch (Exception ex)
+            {
+                _logger.Log(LogLevel.Error, this, LogFunction.Read, "AssessmentNote Get Failed {AssessmentId} {Error}", id, ex.ToString());
+                return StatusCode(StatusCodes.Status500InternalServerError);
+            }
+        }
+
+        [HttpGet("grower/{growerId}/notes")]
+        [Authorize]
+        public async Task<ActionResult<IEnumerable<Models.AssessmentNote>>> GetNotesByGrower(int growerId)
+        {
+            try
+            {
+                var notes = await _assessmentService.GetNotesByGrowerAsync(growerId);
+                return Ok(notes);
+            }
+            catch (Exception ex)
+            {
+                _logger.Log(LogLevel.Error, this, LogFunction.Read, "AssessmentNote Get By Grower Failed {GrowerId} {Error}", growerId, ex.ToString());
+                return StatusCode(StatusCodes.Status500InternalServerError);
+            }
+        }
+
+        [HttpPost("{id}/notes")]
+        [Authorize]
+        public async Task<ActionResult<Models.AssessmentNote>> PostNote(int id, [FromBody] Models.AssessmentNote note)
+        {
+            try
+            {
+                if (note == null || note.AssessmentId != id)
+                {
+                    _logger.Log(LogLevel.Error, this, LogFunction.Create, "AssessmentNote Add Failed Id Mismatch {RouteId} {AssessmentId}", id, note?.AssessmentId);
+                    return BadRequest();
+                }
+
+                if (string.IsNullOrWhiteSpace(note.Text))
+                {
+                    _logger.Log(LogLevel.Error, this, LogFunction.Create, "AssessmentNote Add Failed Empty Text {AssessmentId}", id);
+                    return BadRequest();
+                }
+
+                if (!ModelState.IsValid)
+                {
+                    _logger.Log(LogLevel.Error, this, LogFunction.Create, "AssessmentNote Add Failed Validation {AssessmentNote}", note);
+                    return BadRequest(ModelState);
+                }
+
+                var created = await _assessmentService.AddNoteAsync(note);
+                if (created == null)
+                {
+                    return NotFound();
+                }
+
+                _logger.Log(LogLevel.Information, this, LogFunction.Create, "AssessmentNote Added {AssessmentNote}", created);
+                return Ok(created);
+            }
+            catch (Exception ex)
+            {
+                _logger.Log(LogLevel.Error, this, LogFunction.Create, "AssessmentNote Add Failed {AssessmentId} {Error}", id, ex.ToString());
+                return StatusCode(StatusCodes.Status500InternalServerError);
+            }
+        }
     }
 }

--- a/Server/Repository/AssessmentNoteRepository.cs
+++ b/Server/Repository/AssessmentNoteRepository.cs
@@ -1,0 +1,60 @@
+using Microsoft.EntityFrameworkCore;
+using System.Collections.Generic;
+using System.Linq;
+using Oqtane.Modules;
+using OpenEug.TenTrees.Models;
+
+namespace OpenEug.TenTrees.Module.Assessment.Repository
+{
+    public interface IAssessmentNoteRepository
+    {
+        IEnumerable<AssessmentNote> GetNotesByAssessment(int assessmentId);
+        IEnumerable<AssessmentNote> GetNotesByGrower(int growerId);
+        AssessmentNote GetNote(int assessmentNoteId);
+        AssessmentNote AddNote(AssessmentNote note);
+    }
+
+    public class AssessmentNoteRepository : IAssessmentNoteRepository, ITransientService
+    {
+        private readonly IDbContextFactory<OpenEug.TenTrees.Repository.TenTreesContext> _factory;
+
+        public AssessmentNoteRepository(IDbContextFactory<OpenEug.TenTrees.Repository.TenTreesContext> factory)
+        {
+            _factory = factory;
+        }
+
+        public IEnumerable<AssessmentNote> GetNotesByAssessment(int assessmentId)
+        {
+            using var db = _factory.CreateDbContext();
+            return db.AssessmentNote
+                .Where(n => n.AssessmentId == assessmentId)
+                .OrderBy(n => n.CreatedOn)
+                .ToList();
+        }
+
+        public IEnumerable<AssessmentNote> GetNotesByGrower(int growerId)
+        {
+            using var db = _factory.CreateDbContext();
+            var query = from n in db.AssessmentNote
+                        join a in db.Assessment on n.AssessmentId equals a.AssessmentId
+                        where a.GrowerId == growerId
+                        orderby n.CreatedOn descending
+                        select n;
+            return query.ToList();
+        }
+
+        public AssessmentNote GetNote(int assessmentNoteId)
+        {
+            using var db = _factory.CreateDbContext();
+            return db.AssessmentNote.AsNoTracking().FirstOrDefault(n => n.AssessmentNoteId == assessmentNoteId);
+        }
+
+        public AssessmentNote AddNote(AssessmentNote note)
+        {
+            using var db = _factory.CreateDbContext();
+            db.AssessmentNote.Add(note);
+            db.SaveChanges();
+            return note;
+        }
+    }
+}

--- a/Server/Repository/TenTreesContext.cs
+++ b/Server/Repository/TenTreesContext.cs
@@ -16,6 +16,7 @@ namespace OpenEug.TenTrees.Repository
         public virtual DbSet<Models.TrainingClass> TrainingClass { get; set; }
         public virtual DbSet<Models.ClassAttendance> ClassAttendance { get; set; }
         public virtual DbSet<Models.Assessment> Assessment { get; set; }
+        public virtual DbSet<Models.AssessmentNote> AssessmentNote { get; set; }
         public virtual DbSet<Models.Cohort> Cohort { get; set; }
         public virtual DbSet<Models.GrowerCohort> GrowerCohort { get; set; }
         public virtual DbSet<Models.MentorCohort> MentorCohort { get; set; }
@@ -37,6 +38,7 @@ namespace OpenEug.TenTrees.Repository
             modelBuilder.Entity<Models.TrainingClass>().ToTable(ActiveDatabase.RewriteName("TrainingClass"));
             modelBuilder.Entity<Models.ClassAttendance>().ToTable(ActiveDatabase.RewriteName("ClassAttendance"));
             modelBuilder.Entity<Models.Assessment>().ToTable(ActiveDatabase.RewriteName("Assessment"));
+            modelBuilder.Entity<Models.AssessmentNote>().ToTable(ActiveDatabase.RewriteName("AssessmentNote"));
             modelBuilder.Entity<Models.Cohort>().ToTable(ActiveDatabase.RewriteName("Cohort"));
             modelBuilder.Entity<Models.GrowerCohort>().ToTable(ActiveDatabase.RewriteName("GrowerCohort"));
             modelBuilder.Entity<Models.MentorCohort>().ToTable(ActiveDatabase.RewriteName("MentorCohort"));

--- a/Server/Services/AssessmentService.cs
+++ b/Server/Services/AssessmentService.cs
@@ -15,17 +15,20 @@ namespace OpenEug.TenTrees.Module.Assessment.Services
     public class ServerAssessmentService : IAssessmentService
     {
         private readonly IAssessmentRepository _assessmentRepository;
+        private readonly IAssessmentNoteRepository _assessmentNoteRepository;
         private readonly IGrowerRepository _growerRepository;
         private readonly ICohortRepository _cohortRepository;
         private readonly ILogManager _logger;
 
         public ServerAssessmentService(
             IAssessmentRepository assessmentRepository,
+            IAssessmentNoteRepository assessmentNoteRepository,
             IGrowerRepository growerRepository,
             ICohortRepository cohortRepository,
             ILogManager logger)
         {
             _assessmentRepository = assessmentRepository;
+            _assessmentNoteRepository = assessmentNoteRepository;
             _growerRepository = growerRepository;
             _cohortRepository = cohortRepository;
             _logger = logger;
@@ -147,6 +150,42 @@ namespace OpenEug.TenTrees.Module.Assessment.Services
         {
             var list = _assessmentRepository.GetAssessmentList(villageId, cohortId, mentorUsername, growerId).ToList();
             return Task.FromResult(list);
+        }
+
+        public Task<List<Models.AssessmentNote>> GetNotesByAssessmentAsync(int assessmentId)
+        {
+            return Task.FromResult(_assessmentNoteRepository.GetNotesByAssessment(assessmentId).ToList());
+        }
+
+        public Task<List<Models.AssessmentNote>> GetNotesByGrowerAsync(int growerId)
+        {
+            return Task.FromResult(_assessmentNoteRepository.GetNotesByGrower(growerId).ToList());
+        }
+
+        public Task<Models.AssessmentNote> AddNoteAsync(Models.AssessmentNote note)
+        {
+            if (note == null)
+            {
+                return Task.FromResult<Models.AssessmentNote>(null);
+            }
+
+            // Normalise note type to a known value so we don't end up with
+            // arbitrary strings in the database from a malformed client.
+            if (note.NoteType != AssessmentNoteTypes.HomeVisit)
+            {
+                note.NoteType = AssessmentNoteTypes.General;
+            }
+
+            var assessment = _assessmentRepository.GetAssessment(note.AssessmentId, tracking: false);
+            if (assessment == null)
+            {
+                _logger.Log(LogLevel.Error, this, LogFunction.Create, "AssessmentNote Add Failed — Assessment not found {AssessmentId}", note.AssessmentId);
+                return Task.FromResult<Models.AssessmentNote>(null);
+            }
+
+            var created = _assessmentNoteRepository.AddNote(note);
+            _logger.Log(LogLevel.Information, this, LogFunction.Create, "AssessmentNote Added {AssessmentNote}", created);
+            return Task.FromResult(created);
         }
     }
 }

--- a/Server/Startup/AssessmentServerStartup.cs
+++ b/Server/Startup/AssessmentServerStartup.cs
@@ -24,6 +24,7 @@ namespace OpenEug.TenTrees.Module.Assessment.Startup
         {
             services.AddTransient<IAssessmentService, ServerAssessmentService>();
             services.AddTransient<IAssessmentRepository, AssessmentRepository>();
+            services.AddTransient<IAssessmentNoteRepository, AssessmentNoteRepository>();
             services.AddTransient<ICohortRepository, CohortRepository>();
         }
     }

--- a/Shared/Models/Assessment.cs
+++ b/Shared/Models/Assessment.cs
@@ -44,9 +44,6 @@ namespace OpenEug.TenTrees.Models
         public bool HasPests { get; set; }
         public bool NeedsHelp { get; set; }
 
-        // Notes
-        public string? Notes { get; set; }
-
         // Access Control / Submission
         public string? SubmittedBy { get; set; }
         public bool EnteredByAdmin { get; set; }

--- a/Shared/Models/AssessmentNote.cs
+++ b/Shared/Models/AssessmentNote.cs
@@ -1,0 +1,29 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Oqtane.Models;
+
+namespace OpenEug.TenTrees.Models
+{
+    public static class AssessmentNoteTypes
+    {
+        public const string General = "General";
+        public const string HomeVisit = "HomeVisit";
+    }
+
+    [Table("AssessmentNote")]
+    public class AssessmentNote : ModelBase
+    {
+        [Key]
+        public int AssessmentNoteId { get; set; }
+
+        [Required]
+        public int AssessmentId { get; set; }
+
+        [Required]
+        [MaxLength(20)]
+        public string NoteType { get; set; }
+
+        [Required]
+        public string Text { get; set; }
+    }
+}

--- a/Shared/Services/IAssessmentService.cs
+++ b/Shared/Services/IAssessmentService.cs
@@ -14,5 +14,9 @@ namespace OpenEug.TenTrees.Module.Assessment.Services
         Task DeleteAssessmentAsync(int assessmentId);
         Task<bool> CanSubmitAssessmentAsync(int growerId);
         Task<List<AssessmentListDto>> GetAssessmentListAsync(int? villageId = null, int? cohortId = null, string mentorUsername = null, int? growerId = null);
+
+        Task<List<Models.AssessmentNote>> GetNotesByAssessmentAsync(int assessmentId);
+        Task<List<Models.AssessmentNote>> GetNotesByGrowerAsync(int growerId);
+        Task<Models.AssessmentNote> AddNoteAsync(Models.AssessmentNote note);
     }
 }

--- a/Sql/Scripts/Migration_AddAssessmentNoteTable.sql
+++ b/Sql/Scripts/Migration_AddAssessmentNoteTable.sql
@@ -1,0 +1,72 @@
+-- Migration: add [dbo].[AssessmentNote] table, migrate any existing
+-- [dbo].[Assessment].[Notes] content into the new table as a single
+-- General-typed log entry, then drop the old Notes column.
+--
+-- Safe to re-run: every step is guarded with an existence check.
+-- Run once against each target database after deploying the code change.
+
+SET NOCOUNT ON;
+SET XACT_ABORT ON;
+
+BEGIN TRANSACTION;
+
+-- 1. Create the AssessmentNote table if it doesn't already exist.
+IF NOT EXISTS (
+    SELECT 1 FROM sys.tables
+    WHERE object_id = OBJECT_ID(N'[dbo].[AssessmentNote]')
+)
+BEGIN
+    CREATE TABLE [dbo].[AssessmentNote] (
+        [AssessmentNoteId] INT            IDENTITY (1, 1) NOT NULL,
+        [AssessmentId]     INT            NOT NULL,
+        [NoteType]         NVARCHAR (20)  NOT NULL,
+        [Text]             NVARCHAR (MAX) NOT NULL,
+        [CreatedBy]        NVARCHAR (256) NOT NULL,
+        [CreatedOn]        DATETIME2 (7)  NOT NULL,
+        [ModifiedBy]       NVARCHAR (256) NOT NULL,
+        [ModifiedOn]       DATETIME2 (7)  NOT NULL,
+        CONSTRAINT [PK_AssessmentNote] PRIMARY KEY CLUSTERED ([AssessmentNoteId] ASC),
+        CONSTRAINT [FK_AssessmentNote_Assessment] FOREIGN KEY ([AssessmentId])
+            REFERENCES [dbo].[Assessment] ([AssessmentId]) ON DELETE CASCADE
+    );
+
+    CREATE NONCLUSTERED INDEX [IX_AssessmentNote_AssessmentId]
+        ON [dbo].[AssessmentNote] ([AssessmentId] ASC);
+END;
+
+-- 2. If the legacy Notes column still exists, copy every non-empty value
+--    into AssessmentNote as a General-typed entry stamped with the
+--    assessment's original CreatedBy / CreatedOn so history is preserved.
+IF EXISTS (
+    SELECT 1 FROM sys.columns
+    WHERE object_id = OBJECT_ID(N'[dbo].[Assessment]') AND name = N'Notes'
+)
+BEGIN
+    -- Guard against repeat runs: only insert notes for assessments that
+    -- don't already have a migrated entry.
+    DECLARE @sql NVARCHAR(MAX) = N'
+        INSERT INTO [dbo].[AssessmentNote]
+            ([AssessmentId], [NoteType], [Text], [CreatedBy], [CreatedOn], [ModifiedBy], [ModifiedOn])
+        SELECT
+            a.[AssessmentId],
+            N''General'',
+            a.[Notes],
+            a.[CreatedBy],
+            a.[CreatedOn],
+            a.[ModifiedBy],
+            a.[ModifiedOn]
+        FROM [dbo].[Assessment] a
+        WHERE a.[Notes] IS NOT NULL
+          AND LTRIM(RTRIM(a.[Notes])) <> N''''
+          AND NOT EXISTS (
+              SELECT 1 FROM [dbo].[AssessmentNote] n
+              WHERE n.[AssessmentId] = a.[AssessmentId]
+          );
+    ';
+    EXEC sp_executesql @sql;
+
+    -- 3. Drop the legacy Notes column now that its data has been migrated.
+    ALTER TABLE [dbo].[Assessment] DROP COLUMN [Notes];
+END;
+
+COMMIT TRANSACTION;

--- a/Sql/Sql.sqlproj
+++ b/Sql/Sql.sqlproj
@@ -100,6 +100,7 @@
     <Build Include="dbo\Tables\TrainingClass.sql" />
     <Build Include="dbo\Tables\ClassAttendance.sql" />
     <Build Include="dbo\Tables\Assessment.sql" />
+    <Build Include="dbo\Tables\AssessmentNote.sql" />
     <Build Include="dbo\Tables\SiteTask.sql" />
     <Build Include="dbo\Tables\SiteGroupMember.sql" />
     <Build Include="dbo\Tables\SiteGroup.sql" />

--- a/Sql/dbo/Tables/Assessment.sql
+++ b/Sql/dbo/Tables/Assessment.sql
@@ -22,7 +22,6 @@ CREATE TABLE [dbo].[Assessment] (
     [HasLookDry]                     BIT            NOT NULL,
     [HasPests]                       BIT            NOT NULL,
     [NeedsHelp]                      BIT            NOT NULL,
-    [Notes]                          NVARCHAR (MAX) NULL,
     [SubmittedBy]                    NVARCHAR (256) NULL,
     [EnteredByAdmin]                 BIT            NOT NULL,
     [FrequencyType]                  NVARCHAR (50)  NULL,

--- a/Sql/dbo/Tables/AssessmentNote.sql
+++ b/Sql/dbo/Tables/AssessmentNote.sql
@@ -1,0 +1,16 @@
+CREATE TABLE [dbo].[AssessmentNote] (
+    [AssessmentNoteId] INT            IDENTITY (1, 1) NOT NULL,
+    [AssessmentId]     INT            NOT NULL,
+    [NoteType]         NVARCHAR (20)  NOT NULL,
+    [Text]             NVARCHAR (MAX) NOT NULL,
+    [CreatedBy]        NVARCHAR (256) NOT NULL,
+    [CreatedOn]        DATETIME2 (7)  NOT NULL,
+    [ModifiedBy]       NVARCHAR (256) NOT NULL,
+    [ModifiedOn]       DATETIME2 (7)  NOT NULL,
+    CONSTRAINT [PK_AssessmentNote] PRIMARY KEY CLUSTERED ([AssessmentNoteId] ASC),
+    CONSTRAINT [FK_AssessmentNote_Assessment] FOREIGN KEY ([AssessmentId]) REFERENCES [dbo].[Assessment] ([AssessmentId]) ON DELETE CASCADE
+);
+GO
+
+CREATE NONCLUSTERED INDEX [IX_AssessmentNote_AssessmentId]
+    ON [dbo].[AssessmentNote] ([AssessmentId] ASC);


### PR DESCRIPTION
## Summary
This PR transforms assessment notes from a simple text field into a structured audit log system with support for multiple note types (General and Home Visit). Notes are now persisted as individual records with timestamps and creator information, enabling better tracking and organization of assessment observations.

## Key Changes

- **New AssessmentNote model and database table**: Created `AssessmentNote` entity with fields for note type, text, and audit metadata (CreatedBy, CreatedOn, ModifiedBy, ModifiedOn). Includes a migration script to safely migrate existing notes from the Assessment table.

- **Notes UI redesigned as a log viewer**: The Assessment edit form now displays notes as a chronological list with badges indicating note type and metadata. Pending notes (not yet saved) are shown with a distinct visual style and can be removed before saving.

- **Pending notes workflow**: Notes are queued locally before submission. When an assessment is saved, pending notes are persisted to the database via new API endpoints. Draft recovery now includes pending notes.

- **Note type support**: Added `AssessmentNoteTypes` constants (General, HomeVisit) with UI controls to classify notes. When "Needs Help" is flagged, the note composer pre-selects Home Visit type.

- **New API endpoints**: 
  - `GET /assessment/{id}/notes` - retrieve notes for an assessment
  - `GET /assessment/grower/{growerId}/notes` - retrieve all notes for a grower
  - `POST /assessment/{id}/notes` - create a new note

- **Grower Status page enhancement**: Added a Notes & Home Visits card displaying all notes for a grower with type badges and counts.

- **Service layer updates**: Extended `IAssessmentService` with methods to get and add notes. Server-side validation normalizes note types and verifies assessment existence.

- **Draft versioning**: Updated draft key to `TenTrees_Assessment_Draft_V2` and created `AssessmentDraft` wrapper class to include pending notes in local storage.

## Implementation Details

- Notes are immutable once saved (no edit capability) to maintain audit trail integrity
- The UI prevents adding empty notes and shows helpful messaging when no notes exist
- Home Visit notes are highlighted with a warning badge to draw attention to flagged assessments
- Draft recovery preserves pending notes, allowing users to resume work without losing unsaved observations
- Database migration is idempotent and safe to re-run

https://claude.ai/code/session_018KiX3o2XpGWgpSDsyFTZE4