### PR TITLE
Bump module versions to 2.2.0 and update release lists

### DIFF
--- a/Client/Modules/Assessment/ModuleInfo.cs
+++ b/Client/Modules/Assessment/ModuleInfo.cs
@@ -11,9 +11,9 @@ namespace OpenEug.TenTrees.Module.Assessment
         {
             Name = "Assessment",
             Description = "Garden Assessment and Tree Monitoring",
-            Version = "2.1.0",
+            Version = "2.2.0",
             ServerManagerType = "",
-            ReleaseVersions = "1.0.0,1.0.1,1.0.2,1.0.3,1.0.4,1.0.5,2.1.0",
+            ReleaseVersions = "1.0.0,1.0.1,1.0.2,1.0.3,1.0.4,1.0.5,2.1.0,2.2.0",
             Dependencies = "OpenEug.TenTrees.Module.Grower.1.0.0",
             PackageName = "OpenEug.TenTrees.Module.Assessment"
         };

--- a/Client/Modules/Cohort/ModuleInfo.cs
+++ b/Client/Modules/Cohort/ModuleInfo.cs
@@ -9,9 +9,9 @@ namespace OpenEug.TenTrees.Module.Cohort
         {
             Name = "Cohort",
             Description = "Cohort Management",
-            Version = "2.1.0",
+            Version = "2.2.0",
             ServerManagerType = "",
-            ReleaseVersions = "1.0.0,1.0.1,1.0.2,1.0.3,1.0.4,2.1.0",
+            ReleaseVersions = "1.0.0,1.0.1,1.0.2,1.0.3,1.0.4,2.1.0,2.2.0",
             Dependencies = ""
         };
     }

--- a/Client/Modules/Enrollment/ModuleInfo.cs
+++ b/Client/Modules/Enrollment/ModuleInfo.cs
@@ -11,9 +11,9 @@ namespace OpenEug.TenTrees.Module.Enrollment
         {
             Name = "Enrollment",
             Description = "Grower Enrollment Submission",
-            Version = "2.1.0",
+            Version = "2.2.0",
             ServerManagerType = "",
-            ReleaseVersions = "1.0.0,1.1.0,1.1.1,1.2.0,1.2.1,1.3.0,2.0.0,2.0.1,2.0.2,2.0.3,2.0.4,2.0.5,2.0.6,2.1.0",
+            ReleaseVersions = "1.0.0,1.1.0,1.1.1,1.2.0,1.2.1,1.3.0,2.0.0,2.0.1,2.0.2,2.0.3,2.0.4,2.0.5,2.0.6,2.1.0,2.2.0",
             Dependencies = "",
             Resources = new List<Resource>
             {

--- a/Client/Modules/Grower/ModuleInfo.cs
+++ b/Client/Modules/Grower/ModuleInfo.cs
@@ -10,9 +10,9 @@ namespace OpenEug.TenTrees.Module.Grower
         {
             Name = "Grower",
             Description = "Grower management for 10 Trees program - track active status and program exits",
-            Version = "2.1.0",
+            Version = "2.2.0",
             ServerManagerType = "",
-            ReleaseVersions = "1.0.0,1.0.1,1.0.2,1.0.3,1.0.4,1.0.5,2.1.0",
+            ReleaseVersions = "1.0.0,1.0.1,1.0.2,1.0.3,1.0.4,1.0.5,2.1.0,2.2.0",
             Dependencies = "OpenEug.TenTrees.Module.Village.1.0.0",
             PackageName = "OpenEug.TenTrees.Module.Grower"
         };

--- a/Client/Modules/Mentor/ModuleInfo.cs
+++ b/Client/Modules/Mentor/ModuleInfo.cs
@@ -9,9 +9,9 @@ namespace OpenEug.TenTrees.Module.Mentor
         {
             Name = "Mentor",
             Description = "Mentor user management — create, edit, activate/deactivate mentors and assign growers",
-            Version = "2.1.0",
+            Version = "2.2.0",
             ServerManagerType = "",
-            ReleaseVersions = "1.0.0,1.0.1,1.0.2,1.0.3,1.0.4,1.0.5,2.1.0",
+            ReleaseVersions = "1.0.0,1.0.1,1.0.2,1.0.3,1.0.4,1.0.5,2.1.0,2.2.0",
             Dependencies = "OpenEug.TenTrees.Module.Village.1.0.0",
             PackageName = "OpenEug.TenTrees.Module.Mentor"
         };

--- a/Client/Modules/Training/ModuleInfo.cs
+++ b/Client/Modules/Training/ModuleInfo.cs
@@ -9,9 +9,9 @@ namespace OpenEug.TenTrees.Module.Training
         {
             Name = "Training",
             Description = "Permaculture training class management and attendance tracking for tree eligibility",
-            Version = "2.1.0",
+            Version = "2.2.0",
             ServerManagerType = "",
-            ReleaseVersions = "1.0.0,1.0.1,1.0.2,1.0.3,1.0.4,1.0.5,2.1.0",
+            ReleaseVersions = "1.0.0,1.0.1,1.0.2,1.0.3,1.0.4,1.0.5,2.1.0,2.2.0",
             Dependencies = "OpenEug.TenTrees.Module.Village.1.0.0,OpenEug.TenTrees.Module.Grower.1.0.0",
             PackageName = "OpenEug.TenTrees.Module.Training"
         };

--- a/Client/Modules/TreeType/ModuleInfo.cs
+++ b/Client/Modules/TreeType/ModuleInfo.cs
@@ -9,9 +9,9 @@ namespace OpenEug.TenTrees.Module.TreeType
         {
             Name = "TreeType",
             Description = "Tree Type Management",
-            Version = "2.1.0",
+            Version = "2.2.0",
             ServerManagerType = "",
-            ReleaseVersions = "1.0.0,2.1.0",
+            ReleaseVersions = "1.0.0,2.1.0,2.2.0",
             Dependencies = ""
         };
     }

--- a/Client/Modules/Village/ModuleInfo.cs
+++ b/Client/Modules/Village/ModuleInfo.cs
@@ -9,9 +9,9 @@ namespace OpenEug.TenTrees.Module.Village
         {
             Name = "Village",
             Description = "Village Management",
-            Version = "2.1.0",
+            Version = "2.2.0",
             ServerManagerType = "",
-            ReleaseVersions = "1.0.0,1.1.0,1.1.1,1.1.2,1.1.3,1.1.4,1.1.5,2.1.0",
+            ReleaseVersions = "1.0.0,1.1.0,1.1.1,1.1.2,1.1.3,1.1.4,1.1.5,2.1.0,2.2.0",
             Dependencies = ""
         };
     }


### PR DESCRIPTION
Bump module versions to 2.2.0 and update release lists

Incremented version numbers to 2.2.0 for all modules (Assessment, Cohort, Enrollment, Grower, Mentor, Training, TreeType, Village) in their ModuleInfo.cs files. Updated ReleaseVersions properties to include 2.2.0. No other changes made.