### PR TITLE
fix: remove Executive Director role from all code, docs, and kanban (…

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Generate reports and export data:
 Multi-tenant architecture with role-based access:
 - **Mentors**: View only their assigned village
 - **Educators/Project Managers**: View all villages, export data
-- **Administrators/Executive Director**: Full access including user management
+- **10 Trees Admin**: Full access including user management
 
 ### 7. Localization & Language Support
 Comprehensive bilingual implementation:
@@ -113,8 +113,7 @@ Specs/
 | **Mentor** | Submit forms, view assigned village only |
 | **Educator** | Submit forms, view all villages, export data |
 | **Project Manager** | Same as Educator |
-| **Administrator** | Full access including user management |
-| **Executive Director** | Full access |
+| **10 Trees Admin** | Full programme data access including user management |
 
 ## Design Principles
 

--- a/README_ROLES.md
+++ b/README_ROLES.md
@@ -3,21 +3,23 @@
 ## Overview
 The 10 Trees application requires four custom roles beyond the standard Oqtane roles. These roles must be created manually through the Oqtane admin UI or by running the provided SQL script.
 
+> **Note:** There is no Executive Director role. The organisation uses a distributed leadership model. Full programme data access and user management is handled by the **10 Trees Admin** role.
+
 ## Required Custom Roles
 
 | Role | Description | Permissions |
 |------|-------------|-------------|
-| **Mentor** | Field mentor who submits forms and views assigned village data only | Submit forms, view assigned village only |
-| **Educator** | Educator who submits forms, views all villages, and exports data | Submit forms, view all villages, export data |
-| **Project Manager** | Project manager with same permissions as Educator | Submit forms, view all villages, export data |
-| **Executive Director** | Executive director with full permissions including user management | Submit forms, view all villages, export data, manage users |
+| **Mentor** | Field mentor who submits forms and views assigned village/cohort data only | Submit forms, view assigned village/cohort only |
+| **Educator** | Educator who views all villages, adds home-visit notes, and marks class attendance | View all villages, add notes, mark attendance |
+| **Project Manager** | Same as Educator, plus data export and full reporting access | View all villages, add notes, mark attendance, export data, view reports |
+| **10 Trees Admin** | Programme-level administrator with full data access and user management | Full programme data access, manage users |
 
 ## Setup Methods
 
 ### Method 1: Manual Creation (Recommended for Production)
 
 1. Log in to Oqtane as an Administrator
-2. Navigate to **Control Panel** ? **User Management** ? **Roles**
+2. Navigate to **Control Panel** → **User Management** → **Roles**
 3. Click **Add Role** and create each role with these settings:
    - **Name**: (See table above)
    - **Description**: (See table above)
@@ -46,36 +48,36 @@ The 10 Trees application requires four custom roles beyond the standard Oqtane r
    ```sql
    SELECT [RoleId], [SiteId], [Name], [Description], [IsSystem]
    FROM [dbo].[Role]
-   WHERE [Name] IN ('Mentor', 'Educator', 'Project Manager', 'Executive Director')
+   WHERE [Name] IN ('Mentor', 'Educator', 'Project Manager', '10 Trees Admin')
    ORDER BY [Name]
    ```
 
 ## Using Roles in Code
 
-The `Shared/RoleNames.cs` class provides type-safe constants for all roles:
+The `Shared/AppRoleNames.cs` class provides type-safe constants for all roles:
 
 ```csharp
 using OpenEug.TenTrees.Shared;
 
 // Check specific role
-if (User.IsInRole(RoleNames.Mentor))
+if (User.IsInRole(AppRoleNames.Mentor))
 {
     // Mentor-specific logic
 }
 
 // Check permissions
-if (RoleNames.CanViewAllVillages(userRole))
+if (AppRoleNames.CanViewAllVillages(userRole))
 {
     // Show all village data
 }
 
-if (RoleNames.CanExportData(userRole))
+if (AppRoleNames.CanExportData(userRole))
 {
     // Enable export functionality
 }
 
 // Controller authorization
-[Authorize(Roles = RoleNames.Educator + "," + RoleNames.ProjectManager + "," + RoleNames.Admin)]
+[Authorize(Roles = AppRoleNames.Educator + "," + AppRoleNames.ProjectManager + "," + AppRoleNames.TenTreesAdmin)]
 public async Task<ActionResult> GetAllVillages()
 {
     // ...
@@ -84,7 +86,7 @@ public async Task<ActionResult> GetAllVillages()
 
 ## Assigning Users to Roles
 
-1. Navigate to **Control Panel** ? **User Management** ? **Users**
+1. Navigate to **Control Panel** → **User Management** → **Users**
 2. Select a user
 3. Click **Edit Roles**
 4. Select the appropriate role(s)
@@ -108,10 +110,10 @@ Mentors must also be assigned to a specific village:
 
 **Permission denied errors:**
 - Verify the user has the correct role assigned
-- Check that the role name exactly matches the constants in `RoleNames.cs`
+- Check that the role name exactly matches the constants in `AppRoleNames.cs`
 - Ensure the user is logged in and authenticated
 
 ## Related Files
-- `Shared/RoleNames.cs` - Role name constants and permission helpers
+- `Shared/AppRoleNames.cs` - Role name constants and permission helpers
 - `Server/Migrations/Scripts/CreateCustomRoles.sql` - SQL script for role creation
 - `Specs/Features/UserAdministration.feature` - BDD scenarios for role behavior

--- a/Shared/AppRoleNames.cs
+++ b/Shared/AppRoleNames.cs
@@ -11,28 +11,22 @@ namespace OpenEug.TenTrees.Shared
         // ========== Custom 10 Trees Roles ==========
 
         /// <summary>
-        /// Mentor - Field mentor who submits forms and views assigned village data only
-        /// Permissions: Submit forms, view assigned village only
+        /// Mentor - Field mentor who submits forms and views assigned village/cohort data only
+        /// Permissions: Submit forms, view assigned village/cohort only
         /// </summary>
         public const string Mentor = "Mentor";
 
         /// <summary>
-        /// Educator - Educator who submits forms, views all villages, and exports data
-        /// Permissions: Submit forms, view all villages, export data
+        /// Educator - Educator who views all villages, adds home-visit notes, and marks class attendance
+        /// Permissions: View all villages, add notes, mark attendance
         /// </summary>
         public const string Educator = "Educator";
 
         /// <summary>
-        /// Project Manager - Project manager with same permissions as Educator
-        /// Permissions: Submit forms, view all villages, export data
+        /// Project Manager - Same as Educator, plus data export and full reporting access
+        /// Permissions: View all villages, add notes, mark attendance, export data, view reports
         /// </summary>
         public const string ProjectManager = "Project Manager";
-
-        /// <summary>
-        /// Executive Director - Executive director with full permissions including user management
-        /// Permissions: Submit forms, view all villages, export data, manage users
-        /// </summary>
-        public const string ExecutiveDirector = "Executive Director";
 
         /// <summary>
         /// 10 Trees Admin - Programme-level administrator with full data access and user management.
@@ -70,7 +64,6 @@ namespace OpenEug.TenTrees.Shared
         {
             return roleName == Educator
                 || roleName == ProjectManager
-                || roleName == ExecutiveDirector
                 || roleName == TenTreesAdmin;
         }
 
@@ -79,9 +72,7 @@ namespace OpenEug.TenTrees.Shared
         /// </summary>
         public static bool CanExportData(string roleName)
         {
-            return roleName == Educator
-                || roleName == ProjectManager
-                || roleName == ExecutiveDirector
+            return roleName == ProjectManager
                 || roleName == TenTreesAdmin;
         }
 
@@ -90,8 +81,7 @@ namespace OpenEug.TenTrees.Shared
         /// </summary>
         public static bool CanManageUsers(string roleName)
         {
-            return roleName == ExecutiveDirector
-                || roleName == TenTreesAdmin;
+            return roleName == TenTreesAdmin;
         }
     }
 }

--- a/Specs/Docs/10_Trees_BDD_Project_Plan.md
+++ b/Specs/Docs/10_Trees_BDD_Project_Plan.md
@@ -33,7 +33,7 @@ This document provides a comprehensive Behavior-Driven Development (BDD) project
 
 - **Mentors (17 total):** Field staff collecting data on smartphones
 - **Centre Staff:** 10 Trees Admin, Project Manager, Educator (permaculture educator; final role title TBD — Rebecca to confirm with Tri)
-  *(Note: there is no Executive Director. The organisation uses a distributed leadership model. Tri — Director of Permaculture Education and Community Development — leads permaculture work; a new administrator is being hired.)*
+  *(Note: The organisation uses a distributed leadership model. Tri — Director of Permaculture Education and Community Development — leads permaculture work. Full programme admin access is handled by the **10 Trees Admin** role.)*
 - **Growers:** Women in the community receiving trees and training
 - **External Villages:** Future partner organizations using the 10 Trees brand
 
@@ -505,8 +505,7 @@ Feature: User and Access Management
       | Mentor | Yes | No | No | No |
       | Educator | Yes | Yes | Yes | No |
       | Project Manager | Yes | Yes | Yes | No |
-      | Admin | Yes | Yes | Yes | Yes |
-      | Executive Director | Yes | Yes | Yes | Yes |
+      | 10 Trees Admin | Yes | Yes | Yes | Yes |
     When a user logs in with role "Mentor"
     Then they should have permissions matching the Mentor row
 ```

--- a/Specs/Docs/TenTrees.org How-To Guides.md
+++ b/Specs/Docs/TenTrees.org How-To Guides.md
@@ -1,0 +1,117 @@
+# TenTrees.org How-To Guides
+
+Welcome to the official how-to guides for the TenTrees.org platform. This document provides step-by-step instructions for logging in and using the features available to each role.
+
+## 1. How to Log In
+
+All users, regardless of their role, log in through the same portal.
+
+1. Open your web browser and navigate to the TenTrees login page: [https://tentrees.org/login](https://tentrees.org/login)
+2. Enter your assigned **Username** in the "Username" field.
+3. Enter your **Password** in the "Password" field.
+4. (Optional) Check the "Stay Signed In?" box if you are using a personal device.
+5. Click the blue **Login** button.
+6. Upon successful login, you will be redirected to the Home dashboard: [https://tentrees.org/](https://tentrees.org/)
+
+---
+
+## 2. Mentor Guide
+
+Mentors are the field agents who work directly with Growers in their assigned villages.
+
+### 2.1 Enrolling a New Grower
+1. Navigate to the Enrollment module: [https://tentrees.org/enrollment](https://tentrees.org/enrollment)
+2. Click the blue **Add Enrollment** button at the top left.
+3. Fill out the Basic Information form (Grower Name, Village, House Number, ID Number, Birth Date, Household Size).
+4. Click **Next** to proceed through the multi-step wizard to capture all required grower details.
+5. Once completed, the enrollment will appear in the list with a "Pending" status until approved by an Administrator.
+
+### 2.2 Managing Grower Status
+1. Navigate to the Grower module: [https://tentrees.org/grower](https://tentrees.org/grower)
+2. Locate the specific Grower in the list. You can use the "Filter by Village" or "Cohort" dropdowns to narrow the list.
+3. Click the **Manage Status** link in the Actions column for that Grower.
+4. Update their status (e.g., Active, Inactive, Exited) and provide an Exit Date if applicable.
+
+### 2.3 Conducting a Garden Assessment
+1. Navigate to the Assessment module: [https://tentrees.org/assessment](https://tentrees.org/assessment)
+2. Click the **New Assessment** button.
+3. Select the Grower from the dropdown list.
+4. Fill in the Assessment Name (e.g., "GA-1") and Date.
+5. Enter the number of "Trees Planted" and "Trees Still Alive" to calculate the survival rate.
+6. Check any observed problems (e.g., yellow leaves, broken branches, pests).
+7. Answer the Permaculture Practices questions (e.g., fertilizer use, mulching, water collection).
+8. Add any additional notes and click **Save**.
+
+---
+
+## 3. Educator / Teacher Guide
+
+Educators oversee the training programs and manage cohorts across multiple villages.
+
+### 3.1 Managing Cohorts
+1. Navigate to the Cohort module: [https://tentrees.org/cohort](https://tentrees.org/cohort)
+2. To create a new cohort, click **Add Cohort**.
+3. Enter the Cohort Name, select the Village, and set the Status (Planned, Active, Completed).
+4. To edit an existing cohort, click the **Edit** button next to the cohort name in the list.
+
+### 3.2 Overseeing Training Sessions
+1. Navigate to the Classes module: [https://tentrees.org/classes](https://tentrees.org/classes)
+2. Use the filters to view attendance records across different villages and cohorts.
+3. You can add new training sessions or edit existing ones to ensure accurate attendance tracking for all Growers.
+
+### 3.3 Reviewing Assessments
+1. Navigate to the Assessment module: [https://tentrees.org/assessment](https://tentrees.org/assessment)
+2. Use the "Filter by Village", "Cohort", or "Mentor" dropdowns to review assessments submitted by Mentors.
+3. Click **Edit** on any assessment to review the details, survival rates, and permaculture practices recorded.
+
+---
+
+## 4. Project Manager (PM) Guide
+
+Project Managers monitor the overall health of the program, track metrics, and manage resources.
+
+### 4.1 Monitoring Program Metrics
+1. Navigate to the Home dashboard: [https://tentrees.org/](https://tentrees.org/)
+2. Review the high-level metrics and summaries available on the dashboard.
+3. Navigate to the Grower module ([https://tentrees.org/grower](https://tentrees.org/grower)) to view the total number of Active, Inactive, and Exited Growers.
+
+### 4.2 Reviewing Enrollments
+1. Navigate to the Enrollment module: [https://tentrees.org/enrollment](https://tentrees.org/enrollment)
+2. Use the status filters to view "Pending", "Approved", or "Rejected" enrollments.
+3. Review the details of pending enrollments to ensure data quality before they are approved.
+
+### 4.3 Analyzing Assessment Data
+1. Navigate to the Assessment module: [https://tentrees.org/assessment](https://tentrees.org/assessment)
+2. Review the assessment records to identify trends in tree survival rates and common problems (e.g., pests, water issues) across different villages.
+
+---
+
+## 5. Administrator Guide
+
+Administrators have full access to the platform, including user management and system configuration.
+
+### 5.1 Approving Enrollments
+1. Navigate to the Enrollment module: [https://tentrees.org/enrollment](https://tentrees.org/enrollment)
+2. Filter the list by "Pending" status.
+3. Click **Edit** on a pending enrollment.
+4. Review the details and change the status to "Approved" or "Rejected".
+5. Click **Save**. Approved enrollments will automatically create a new Grower record.
+
+### 5.2 Managing Mentors
+1. Navigate to the Mentor module: [https://tentrees.org/mentor](https://tentrees.org/mentor)
+2. To add a new Mentor, click **Add Mentor**.
+3. Fill in the Mentor's details, assign them to a Village, and set their status.
+4. To edit an existing Mentor, click the **Edit** link next to their name.
+5. To deactivate a Mentor, click the **Deactivate** button (the power icon) next to their name.
+
+### 5.3 Managing Villages
+1. Navigate to the Village module: [https://tentrees.org/village](https://tentrees.org/village)
+2. To add a new Village, click **Add Village**.
+3. Enter the Village Name and any required details.
+4. To edit or delete an existing Village, use the **Edit** or **Delete** buttons in the list.
+
+### 5.4 Managing Users and Roles (Oqtane Control Panel)
+1. Log in as an Administrator.
+2. Click the **Gear Icon** (Control Panel) in the top right corner of the navigation bar.
+3. Navigate to **User Management** > **Users** to add, edit, or delete user accounts.
+4. Navigate to **User Management** > **Roles** to manage custom roles (Mentor, Educator, Project Manager, 10 Trees Admin) and assign users to these roles.

--- a/kanban/backlog/configure-role-based-page-permissions.md
+++ b/kanban/backlog/configure-role-based-page-permissions.md
@@ -13,4 +13,4 @@ All authenticated users currently see identical menus regardless of role. Config
 
 - [ ] Establish verified access matrix defining role permissions across 23 pages/modules
 - [ ] Configure Oqtane page permissions to enforce the matrix
-- [ ] Remove unused "Executive Director" role from codebase and documentation
+- [x] Remove unused "Executive Director" role from codebase and documentation

--- a/kanban/backlog/deploy-10-trees-platform-to-codechops-monsterasp.md
+++ b/kanban/backlog/deploy-10-trees-platform-to-codechops-monsterasp.md
@@ -42,7 +42,7 @@ Deploy the 10 Trees Digital Tracking Platform to the CodeChops MonsterASP hostin
 - [ ] Run Entity Framework migrations
 - [ ] Seed initial data:
   - Villages (e.g., Orpen Gate Village, Londelozzi)
-  - User roles (Mentor, Educator, Project Manager, Admin, Executive Director)
+  - User roles (Mentor, Educator, Project Manager, 10 Trees Admin)
   - Initial admin user account
 - [ ] Verify database connectivity from server
 - [ ] Configure backup strategy

--- a/kanban/backlog/implement-program-reporting-data-export-module.md
+++ b/kanban/backlog/implement-program-reporting-data-export-module.md
@@ -71,9 +71,8 @@ Implement comprehensive reporting and data export functionality for program trac
 
 #### ✅ Access Control
 - [ ] Restrict to Centre staff roles:
-  - Admin
+  - 10 Trees Admin
   - Project Manager
-  - Executive Director
   - Educator
 - [ ] Mentors cannot access reports
 - [ ] Admin can view all villages

--- a/kanban/backlog/implement-user-administration-role-management.md
+++ b/kanban/backlog/implement-user-administration-role-management.md
@@ -69,8 +69,7 @@ Implement and enforce the following permissions:
 | Mentor | ✅ Yes | ❌ No | ❌ No | ❌ No |
 | Educator | ✅ Yes | ✅ Yes | ✅ Yes | ❌ No |
 | Project Manager | ✅ Yes | ✅ Yes | ✅ Yes | ❌ No |
-| Admin | ✅ Yes | ✅ Yes | ✅ Yes | ✅ Yes |
-| Executive Director | ✅ Yes | ✅ Yes | ✅ Yes | ✅ Yes |
+| 10 Trees Admin | ✅ Yes | ✅ Yes | ✅ Yes | ✅ Yes |
 
 - [ ] Implement role checks in UI (hide/show features)
 - [ ] Implement role checks in API (authorize attributes)

--- a/kanban/done/add-admin-backfill-growers-maintenance-ui.md
+++ b/kanban/done/add-admin-backfill-growers-maintenance-ui.md
@@ -28,7 +28,7 @@ reports how many Grower records were created.
 
 ## Checklist
 
-- [ ] Add "Backfill Growers" button visible only to Admin/Executive Director roles
+- [ ] Add "Backfill Growers" button visible only to 10 Trees Admin role
 - [ ] Place in `Enrollment/Settings.razor` or as a collapsible admin panel in `Index.razor`
 - [ ] Call `POST api/Enrollment/backfill-growers?moduleId=X`
 - [ ] Display result: "N grower records created" (or "All records up to date" if 0)


### PR DESCRIPTION
…issue #100)

- Removed ExecutiveDirector constant and all references from AppRoleNames.cs
- Updated CanViewAllVillages, CanExportData, CanManageUsers helper methods
- Updated README.md roles table and village data management section
- Rewrote README_ROLES.md to reflect the four active roles
- Updated Specs/Docs/10_Trees_BDD_Project_Plan.md roles table and stakeholder note
- Added TenTrees.org How-To Guides.md to Specs/Docs with corrected role list
- Updated all kanban cards referencing Executive Director
- Marked Executive Director cleanup checklist item as done in configure-role-based-page-permissions.md

Note: Historical references in meeting transcripts (10 Trees march Check-in.md) and agent.md are intentionally preserved as they document why the role was removed.