### PR TITLE
Fix grower save bug, add name sorting, and clarify status meanings

### DIFF
--- a/Client/Modules/Grower/Edit.razor
+++ b/Client/Modules/Grower/Edit.razor
@@ -29,7 +29,11 @@ else
                 @if (_growerId > 0)
                 {
                     <div class="d-flex align-items-center gap-2 flex-wrap">
-                        <span class="badge @GetStatusBadgeClass(_grower.Status)">@GetStatusText(_grower.Status)</span>
+                        <span class="badge @GetStatusBadgeClass(_grower.Status)"
+                              title="@GetStatusDescription(_grower.Status)"
+                              aria-label="Status: @GetStatusText(_grower.Status) â€” @GetStatusDescription(_grower.Status)">
+                            @GetStatusText(_grower.Status)
+                        </span>
                         @if (UserSecurity.IsAuthorized(PageState.User, AppRoleNames.TenTreesAdmin))
                         {
                             @if (_grower.Status == GrowerStatus.Active)
@@ -360,7 +364,7 @@ else
                                         {
                                             <span class="badge bg-secondary me-1">General</span>
                                         }
-                                        <small class="text-muted">@note.CreatedOn.ToLocalTime().ToString("yyyy-MM-dd HH:mm") — @note.CreatedBy</small>
+                                        <small class="text-muted">@note.CreatedOn.ToLocalTime().ToString("yyyy-MM-dd HH:mm") ï¿½ @note.CreatedBy</small>
                                     </div>
                                     <div class="text-body" style="white-space: pre-wrap;">@note.Text</div>
                                 </li>
@@ -656,5 +660,13 @@ else
         GrowerStatus.Inactive => "Inactive",
         GrowerStatus.Exited => "Exited",
         _ => status.ToString()
+    };
+
+    private string GetStatusDescription(GrowerStatus status) => status switch
+    {
+        GrowerStatus.Active => "Currently participating in the program.",
+        GrowerStatus.Inactive => "Temporarily paused (e.g. illness or travel) but has not left the program.",
+        GrowerStatus.Exited => "Has permanently left the program.",
+        _ => string.Empty
     };
 }

--- a/Client/Modules/Grower/Index.razor
+++ b/Client/Modules/Grower/Index.razor
@@ -123,7 +123,8 @@
                         <td>@grower.GrowerName</td>
                         <td>@GetVillageName(grower.VillageId)</td>
                         <td>
-                            <span class="badge @GetStatusBadgeClass(grower.Status)">
+                            <span class="badge @GetStatusBadgeClass(grower.Status)"
+                                  title="@GetStatusDescription(grower.Status)">
                                 @GetStatusText(grower.Status)
                             </span>
                         </td>
@@ -341,6 +342,14 @@
             _ => status.ToString()
         };
     }
+
+    private string GetStatusDescription(GrowerStatus status) => status switch
+    {
+        GrowerStatus.Active => "Currently participating in the program.",
+        GrowerStatus.Inactive => "Temporarily paused (e.g. illness or travel) but has not left the program.",
+        GrowerStatus.Exited => "Has permanently left the program.",
+        _ => string.Empty
+    };
 
     private async Task DeleteGrower(Models.Grower grower)
     {

--- a/Server/Controllers/GrowerController.cs
+++ b/Server/Controllers/GrowerController.cs
@@ -179,7 +179,7 @@ namespace OpenEug.TenTrees.Module.Grower.Controllers
         }
 
         [HttpPut("{id}")]
-        [Authorize]
+        [Authorize(Policy = PolicyNames.EditModule)]
         public async Task<ActionResult<Models.Grower>> Put(int id, [FromBody] Models.Grower grower, int moduleId)
         {
             try

--- a/Server/Repository/GrowerRepository.cs
+++ b/Server/Repository/GrowerRepository.cs
@@ -58,32 +58,32 @@ namespace OpenEug.TenTrees.Module.Grower.Repository
                 query = query.Where(g => g.VillageId == villageId.Value);
             }
 
-            return query.ToList();
+            return query.OrderBy(g => g.GrowerName).ToList();
         }
 
         public IEnumerable<Models.Grower> GetGrowersByVillage(int villageId)
         {
             using var db = _factory.CreateDbContext();
-            return db.Grower.Where(g => g.VillageId == villageId).ToList();
+            return db.Grower.Where(g => g.VillageId == villageId).OrderBy(g => g.GrowerName).ToList();
         }
 
         public IEnumerable<Models.Grower> GetGrowersByMentor(string mentorUsername)
         {
             using var db = _factory.CreateDbContext();
-            return db.Grower.Where(g => g.MentorUsername == mentorUsername).ToList();
+            return db.Grower.Where(g => g.MentorUsername == mentorUsername).OrderBy(g => g.GrowerName).ToList();
         }
 
         public IEnumerable<Models.Grower> GetGrowersByStatus(GrowerStatus status, int? villageId = null)
         {
             using var db = _factory.CreateDbContext();
             var query = db.Grower.Where(g => g.Status == status);
-            
+
             if (villageId.HasValue)
             {
                 query = query.Where(g => g.VillageId == villageId.Value);
             }
-            
-            return query.ToList();
+
+            return query.OrderBy(g => g.GrowerName).ToList();
         }
 
         public IEnumerable<Models.Grower> GetActiveGrowers(int? villageId = null)

--- a/Server/Services/GrowerService.cs
+++ b/Server/Services/GrowerService.cs
@@ -178,16 +178,8 @@ namespace OpenEug.TenTrees.Module.Grower.Services
 
         public Task<Models.Grower> UpdateGrowerAsync(Models.Grower grower, int moduleId)
         {
-            if (_userPermissions.IsAuthorized(_accessor.HttpContext.User, _alias.SiteId, EntityNames.Module, moduleId, PermissionNames.Edit))
-            {
-                grower = _growerRepository.UpdateGrower(grower);
-                _logger.Log(LogLevel.Information, this, LogFunction.Update, "Grower Updated {Grower}", grower);
-            }
-            else
-            {
-                _logger.Log(LogLevel.Error, this, LogFunction.Security, "Unauthorized Grower Update Attempt {Grower}", grower);
-                grower = null;
-            }
+            grower = _growerRepository.UpdateGrower(grower);
+            _logger.Log(LogLevel.Information, this, LogFunction.Update, "Grower Updated {Grower}", grower);
             return Task.FromResult(grower);
         }
 


### PR DESCRIPTION
## Summary

- **Fixes #155** — Grower Edit page save was silently failing for users without explicit "Edit" module permission. The service layer was doing its own `IsAuthorized` check (against CLAUDE.md policy), returning `null` when it failed, which surfaced as "Unable to save changes. Please try again." Removed the service-layer check and aligned the `PUT /{id}` controller endpoint to use `[Authorize(Policy = PolicyNames.EditModule)]`, matching the existing `POST` endpoint.

- **Fixes #161** — Grower list had no consistent ordering. All repository list methods (`GetAllGrowers`, `GetActiveGrowers`, `GetGrowersByStatus`, `GetGrowersByVillage`, `GetGrowersByMentor`) now sort by `GrowerName` alphabetically. Note: since the name is a single field, this sorts by full name — a separate `Surname` column would be needed for true surname-first sorting.

- **Fixes #149** — Status badges in Grower Index and Edit now include a `title` tooltip explaining what each status means on hover: Active (currently participating), Inactive (temporarily paused, still in program), Exited (permanently left).

## Test plan

- [ ] Edit an existing grower record and click Save — confirm it succeeds without "Unable to save changes" error
- [ ] Add a new grower — confirm it saves and redirects to the Edit page
- [ ] Open the Grower list — confirm growers are sorted alphabetically by name
- [ ] Apply a village or status filter — confirm filtered list is also sorted
- [ ] Hover a status badge in the Grower list — confirm tooltip text appears
- [ ] Hover a status badge in Grower Edit — confirm tooltip text appears

https://claude.ai/code/session_013s3rc5YSBFQ5U9Ef1bH13c

---
_Generated by [Claude Code](https://claude.ai/code/session_013s3rc5YSBFQ5U9Ef1bH13c)_