### PR TITLE
Group Home dashboard tiles into Workflow and Admin sections

### DIFF
--- a/Client/Modules/Home/Index.razor
+++ b/Client/Modules/Home/Index.razor
@@ -3,30 +3,26 @@
 @namespace OpenEug.TenTrees.Module.Home
 @inherits ModuleBase
 
-@if (_tiles.Any())
+@if (_workflowTiles.Any() || _adminTiles.Any() || _otherTiles.Any())
 {
-    <div class="row row-cols-1 row-cols-sm-2 row-cols-lg-3 g-3 py-2">
-        @foreach (var tile in _tiles)
-        {
-            <div class="col">
-                <a href="@NavigateUrl(tile.Path)" class="card h-100 text-decoration-none text-reset home-tile">
-                    <div class="card-body">
-                        <h5 class="card-title">
-                            @if (!string.IsNullOrEmpty(tile.Icon))
-                            {
-                                <span class="@tile.Icon me-2" aria-hidden="true"></span>
-                            }
-                            @tile.Name
-                        </h5>
-                        @if (!string.IsNullOrEmpty(tile.Description))
-                        {
-                            <p class="card-text text-muted mb-0">@tile.Description</p>
-                        }
-                    </div>
-                </a>
-            </div>
-        }
-    </div>
+    @if (_workflowTiles.Any())
+    {
+        <h5>Workflow</h5>
+        <hr class="mt-0 mb-3" />
+        @RenderTiles(_workflowTiles)
+    }
+    @if (_adminTiles.Any())
+    {
+        <h5 class="@(_workflowTiles.Any() ? "mt-4" : "")">Admin</h5>
+        <hr class="mt-0 mb-3" />
+        @RenderTiles(_adminTiles)
+    }
+    @if (_otherTiles.Any())
+    {
+        <h5 class="@((_workflowTiles.Any() || _adminTiles.Any()) ? "mt-4" : "")">Other</h5>
+        <hr class="mt-0 mb-3" />
+        @RenderTiles(_otherTiles)
+    }
 }
 else
 {
@@ -34,7 +30,9 @@ else
 }
 
 @code {
-    private List<Tile> _tiles = new();
+    private List<Tile> _workflowTiles = new();
+    private List<Tile> _adminTiles = new();
+    private List<Tile> _otherTiles = new();
 
     private class Tile
     {
@@ -58,18 +56,58 @@ else
         ["Enrollment"] = "Grower Enrollment Submission",
     };
 
+    // the order boxes should appear in - follows the flow of the work rather than PageState's own Page.Order
+    private static readonly string[] _workflowOrder = { "Enrollment", "Classes", "Training", "Grower", "Assessment" };
+    private static readonly string[] _adminOrder = { "Village", "Cohort", "Mentor", "TreeType" };
+
     protected override void OnParametersSet()
     {
-        _tiles = PageState.Pages
+        var pages = PageState.Pages
             .Where(p => p.IsNavigation && p.ParentId == null && p.PageId != PageState.Page.PageId)
-            .OrderBy(p => p.Order)
             .Select(p => new Tile
             {
                 Name = p.Name,
                 Path = p.Path,
                 Icon = p.Icon,
                 Description = _descriptions.TryGetValue(p.Name, out var description) ? description : string.Empty
-            })
+            });
+
+        _workflowTiles = OrderBySection(pages, _workflowOrder);
+        _adminTiles = OrderBySection(pages, _adminOrder);
+
+        var placed = _workflowTiles.Concat(_adminTiles).Select(t => t.Path).ToHashSet();
+        _otherTiles = pages.Where(t => !placed.Contains(t.Path)).OrderBy(t => t.Name).ToList();
+    }
+
+    private static List<Tile> OrderBySection(IEnumerable<Tile> tiles, string[] order)
+    {
+        return order
+            .Select(name => tiles.FirstOrDefault(t => string.Equals(t.Name, name, StringComparison.OrdinalIgnoreCase)))
+            .Where(t => t != null)
+            .DistinctBy(t => t.Path)
             .ToList();
     }
+
+    private RenderFragment RenderTiles(List<Tile> tiles) => @<div class="row row-cols-1 row-cols-sm-2 row-cols-lg-3 g-3 py-2">
+        @foreach (var tile in tiles)
+        {
+            <div class="col">
+                <a href="@NavigateUrl(tile.Path)" class="card h-100 text-decoration-none text-reset home-tile">
+                    <div class="card-body">
+                        <h5 class="card-title">
+                            @if (!string.IsNullOrEmpty(tile.Icon))
+                            {
+                                <span class="@tile.Icon me-2" aria-hidden="true"></span>
+                            }
+                            @tile.Name
+                        </h5>
+                        @if (!string.IsNullOrEmpty(tile.Description))
+                        {
+                            <p class="card-text text-muted mb-0">@tile.Description</p>
+                        }
+                    </div>
+                </a>
+            </div>
+        }
+    </div>;
 }


### PR DESCRIPTION
## Summary
- Reorders the Home dashboard tiles to follow the flow of the work instead of raw CMS page order.
- Splits tiles into two sections:
  - **Workflow**: Enrollment → Classes/Training → Grower → Assessment
  - **Admin**: Village → Cohort → Mentor → TreeType
- Any page that doesn't match either list still renders under an "Other" section, so a future module never silently disappears from the dashboard.

## Test plan
- [x] `dotnet build` succeeds with 0 errors
- [x] Verified in-browser earlier in the session (before this grouping change) that tiles render with correct name/description and navigate correctly when clicked
- [ ] Re-verify the Workflow/Admin grouping visually once merged (local preview sandbox hit an unrelated WASM asset-loading flake in this session that prevented a final screenshot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)