### PR TITLE
Localizes home page and refines Xitsonga strings

### DIFF
--- a/Client/Modules/Home/Index.razor
+++ b/Client/Modules/Home/Index.razor
@@ -5,7 +5,7 @@
 @inject IStringLocalizer<Index> Localizer
 
 <div class="d-flex flex-nowrap">
-    <h2>Welcome to TenTrees Database</h2>
+    <h2>@Localizer["Heading.Welcome"]</h2>
 </div>
 <hr class="app-rule" />
 
@@ -46,6 +46,20 @@ else
         public string Path { get; set; }
         public string Icon { get; set; }
     }
+
+    // tile names keyed by Oqtane page name so display labels can be localized without changing page metadata
+    private static readonly Dictionary<string, string> _tileNameKeys = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["Enrollment"] = "TileName.Enrollment",
+        ["Classes"] = "TileName.Classes",
+        ["Training"] = "TileName.Training",
+        ["Grower"] = "TileName.Grower",
+        ["Assessment"] = "TileName.Assessment",
+        ["Village"] = "TileName.Village",
+        ["Cohort"] = "TileName.Cohort",
+        ["Mentor"] = "TileName.Mentor",
+        ["TreeType"] = "TileName.TreeType",
+    };
 
     // brief descriptions keyed by page name and looked up via resx so they can be localized - Page has no description field of its own
     private static readonly Dictionary<string, string> _descriptionKeys = new(StringComparer.OrdinalIgnoreCase)
@@ -98,6 +112,17 @@ else
             .ToList();
     }
 
+    private string GetTileName(string pageName)
+    {
+        if (!_tileNameKeys.TryGetValue(pageName, out var resourceKey))
+        {
+            return pageName;
+        }
+
+        var localizedName = Localizer[resourceKey];
+        return localizedName.ResourceNotFound ? pageName : localizedName.Value;
+    }
+
     private RenderFragment RenderTiles(List<Tile> tiles) => @<div class="row row-cols-1 row-cols-sm-2 row-cols-lg-3 g-3 py-2">
         @foreach (var tile in tiles)
         {
@@ -109,7 +134,7 @@ else
                             {
                                 <span class="@tile.Icon me-2" aria-hidden="true"></span>
                             }
-                            @tile.Name
+                            @GetTileName(tile.Name)
                         </h5>
                         @if (!string.IsNullOrEmpty(tile.Description))
                         {

--- a/Client/Resources/OpenEug.TenTrees.Module.Assessment/Edit.ts-ZA.resx
+++ b/Client/Resources/OpenEug.TenTrees.Module.Assessment/Edit.ts-ZA.resx
@@ -46,7 +46,7 @@
     <value>Mirhi leyi ha Hanyaka</value>
   </data>
   <data name="DeceasedTrees.Text" xml:space="preserve">
-    <value>[XS] If any died, which ones?</value>
+    <value>Loko yin’wani Yi file hi yini?</value>
   </data>
   <data name="Field.SelectTreeType" xml:space="preserve">
     <value>-- Hlawula Muxaka wa Murhi --</value>
@@ -61,64 +61,64 @@
     <value>Swiphiqo</value>
   </data>
   <data name="ProblemsPrompt" xml:space="preserve">
-    <value>[XS] Which problems do you observe?</value>
+    <value>Hi swihi swiphiqo leswi u swi vona ka?</value>
   </data>
   <data name="Problems.NoTrees" xml:space="preserve">
     <value>A ku si na mirhi leyi tsariweke eka mulimi loyi ha yona.</value>
   </data>
   <data name="Problem.YellowLeaves" xml:space="preserve">
-    <value>[XS] The trees have yellow leaves</value>
+    <value>Mirhi yina matluka ya xitshopana.</value>
   </data>
   <data name="Problem.BrokenBranches" xml:space="preserve">
-    <value>[XS] The trees have broken branches</value>
+    <value>Mirhi yina marhavi lama tshovekeke.</value>
   </data>
   <data name="Problem.LosingLeaves" xml:space="preserve">
-    <value>[XS] The trees are losing their leaves</value>
+    <value>Mirhi yi hlanhlekela matluka.</value>
   </data>
   <data name="Problem.LookDry" xml:space="preserve">
-    <value>[XS] The trees look dry</value>
+    <value>Mirhi yi vona ka yi omile.</value>
   </data>
   <data name="Problem.Pests" xml:space="preserve">
-    <value>[XS] Pests eating the plant</value>
+    <value>Swi tsotswana swidya murhi.</value>
   </data>
   <data name="NeedsHelp" xml:space="preserve">
-    <value>[XS] Do you need someone to help with this problem?</value>
+    <value>Xana ulava munhu wo ku pfuna eka xiphiqo lexi?</value>
   </data>
   <data name="Section.Permaculture" xml:space="preserve">
     <value>Mikhuva ya Permaculture</value>
   </data>
   <data name="Practice.Healthy.Text" xml:space="preserve">
-    <value>[XS] Do the trees look healthy?</value>
+    <value>Xana mirhi yi vonaka yi hanye kahle?</value>
   </data>
   <data name="Practice.Chemicals.Text" xml:space="preserve">
-    <value>[XS] Any chemical fertilizers?</value>
+    <value>Xana kuni manyoro ya tikhemikhali?</value>
   </data>
   <data name="Practice.Pesticides.Text" xml:space="preserve">
-    <value>[XS] Any pesticides used?</value>
+    <value>Xana kuni swi sivela switsotswana?</value>
   </data>
   <data name="Practice.Mulched.Text" xml:space="preserve">
-    <value>[XS] Are the trees mulched?</value>
+    <value>Xana mirhi leyi yi funengetiwile hansi?</value>
   </data>
   <data name="Practice.Compost.Text" xml:space="preserve">
-    <value>[XS] Are they making compost?</value>
+    <value>Xana VA endla manyoro ya swilo swa ntumbuluko?</value>
   </data>
   <data name="Practice.CollectingWater.Text" xml:space="preserve">
-    <value>[XS] Are they collecting water?</value>
+    <value>Xana VA hlengeleta mati?</value>
   </data>
   <data name="Practice.LeakyTaps.Text" xml:space="preserve">
-    <value>[XS] Any leaky taps visible?</value>
+    <value>Xana Kuna lani ku pfutaka mati?</value>
   </data>
   <data name="Practice.GardenDesign.Text" xml:space="preserve">
-    <value>[XS] Is the garden designed to capture water?</value>
+    <value>Xana nsimu yi endliwile hi ndlela yo hlengeleta mati?</value>
   </data>
   <data name="Practice.Greywater.Text" xml:space="preserve">
-    <value>[XS] Are they using greywater?</value>
+    <value>Xana va tirhisa mati lama tirhisiweke?</value>
   </data>
   <data name="Section.Notes" xml:space="preserve">
     <value>Tinotsi</value>
   </data>
   <data name="Notes.Empty" xml:space="preserve">
-    <value>[XS] No notes yet. Add the first observation below.</value>
+    <value>A kuna tinotsi to engetela. Ndzavisiso la hansi.</value>
   </data>
   <data name="Note.TypeGeneral" xml:space="preserve">
     <value>Ntolovelo</value>
@@ -127,13 +127,13 @@
     <value>Ndzendzeleko wa Kaya</value>
   </data>
   <data name="Note.PendingLabel" xml:space="preserve">
-    <value>[XS] Pending — saved when you click Save</value>
+    <value>Yi yimile yita hlayisiwa.</value>
   </data>
   <data name="Note.RemoveAriaLabel" xml:space="preserve">
     <value>Susa xitsalwana lexi yimeleke</value>
   </data>
   <data name="Note.NeedsHelpAlert" xml:space="preserve">
-    <value>[XS] This assessment is flagged as needing help. Please describe the issue below as a Home Visit note.</value>
+    <value>Xikambelo lexi xi kombisiwile tani hi lexi xi lavaka mpfuno. Hi kombela u hlamusela xiphiqo lahansi tani hi tsalwa ro endzela Kaya.</value>
   </data>
   <data name="Note.AddLabel" xml:space="preserve">
     <value>Engetela ntsalwa</value>
@@ -148,7 +148,7 @@
     <value>Engetela Ntsalwa</value>
   </data>
   <data name="Note.ImmutableHint" xml:space="preserve">
-    <value>[XS] Notes are appended to the running log and cannot be edited once saved.</value>
+    <value>Tinotsi ti engeteriwa eka nxaxamelo lowu yaka emahlweni na swona a tinge hundzuriwi loko ti hlayisiwile.</value>
   </data>
   <data name="NotesPlaceholder" xml:space="preserve">
     <value>Nghenisa tinotsi tin'wana laha...</value>
@@ -169,7 +169,7 @@
     <value>Kombela u hlawula mulimi.</value>
   </data>
   <data name="Message.FrequencyError" xml:space="preserve">
-    <value>[XS] An assessment was submitted too recently for this grower.</value>
+    <value>Xikambelwana xi rumeriwile kungari ikhale eka murimi loyi.</value>
   </data>
   <data name="Message.SaveSuccess" xml:space="preserve">
     <value>Xikambelo xa wena xi hlayisiwile.</value>
@@ -211,6 +211,6 @@
     <value>Xihoxo xo susa xikambelo.</value>
   </data>
   <data name="Message.NoteSaveError" xml:space="preserve">
-    <value>[XS] One or more notes could not be saved. Please retry.</value>
+    <value>Tsalwa rinwe kumbe  yo tala a swi koteki ku hlayisiwa. Hi kombela u ringeta na kambe.</value>
   </data>
 </root>

--- a/Client/Resources/OpenEug.TenTrees.Module.Enrollment/PhotoConsent.ts-ZA.resx
+++ b/Client/Resources/OpenEug.TenTrees.Module.Enrollment/PhotoConsent.ts-ZA.resx
@@ -10,27 +10,27 @@
   <data name="Label.Grower" xml:space="preserve"><value>Mulimi</value></data>
   <data name="Label.Village" xml:space="preserve"><value>Rixaka</value></data>
   <data name="Label.Signature" xml:space="preserve"><value>Kusayina: *</value></data>
-  <data name="Consent.Info" xml:space="preserve"><value>[XS] Please select the grower's consent level for photo use and provide their signature below.</value></data>
+  <data name="Consent.Info" xml:space="preserve"><value>Hi kombela u hlawula xiyimo xa mpfumelelano xa murimi xaku tirhisiwa ka swifaniso, u tlhela u nyika nsayino wa vona la hansi.</value></data>
   <data name="Consent.Full.Label" xml:space="preserve"><value>Nvumelano wu Helela</value></data>
-  <data name="Consent.Full.Description" xml:space="preserve"><value>[XS] You may use my photo with my name identified</value></data>
+  <data name="Consent.Full.Description" xml:space="preserve"><value>Minga tirhisa xifaniso xa Mina mi tlhela mi boxa na Vito ra mina.</value></data>
   <data name="Consent.Limited.Label" xml:space="preserve"><value>Nvumelano wu Pimiweke</value></data>
-  <data name="Consent.Limited.Description" xml:space="preserve"><value>[XS] You may use my picture in group photos without my name</value></data>
+  <data name="Consent.Limited.Description" xml:space="preserve"><value>Minga tirhisa xifaniso xa Mina eka swifaniso swa ntlawa handle ko boxa Vito ra Mina.</value></data>
   <data name="Consent.None.Label" xml:space="preserve"><value>A Ku na Nvumelano</value></data>
-  <data name="Consent.None.Description" xml:space="preserve"><value>[XS] You may not use my photo at all</value></data>
+  <data name="Consent.None.Description" xml:space="preserve"><value>A mi fanelanga ku tirhisa xifaniso xa Mina hi ndlela yihi kumbe yihi.</value></data>
   <data name="Signature.Info" xml:space="preserve"><value>Kombela u nyika kusayina ku tiyisisa nhlayo leyi hlawulekeke ya nvumelano</value></data>
   <data name="Signature.Help" xml:space="preserve"><value>Dirowa kusayina ka wena hi xivomba xa wena kumbe mouse</value></data>
   <data name="Signature.Clear" xml:space="preserve"><value>Susa</value></data>
-  <data name="Signature.Confirm" xml:space="preserve"><value>[XS] I confirm this consent level has been explained to and agreed by the grower</value></data>
+  <data name="Signature.Confirm" xml:space="preserve"><value>Ndzi tiyisisa leswaku xiyimo lexi xa mpfumelelano xi hlamuseriwile na swona xi pfumeleriwile hi murimi.</value></data>
   <data name="Action.Save" xml:space="preserve"><value>Hlayisa Nvumelano</value></data>
   <data name="Action.BackToList" xml:space="preserve"><value>Vuya eka Nxaxamelo</value></data>
   <data name="Message.Loading" xml:space="preserve"><value>Nkandziyiso wu laviseka...</value></data>
   <data name="Message.LoadError" xml:space="preserve"><value>Xiphiqo xi Humelele eka ku Loda Nkandziyiso</value></data>
-  <data name="Message.EnrollmentNotFound" xml:space="preserve"><value>[XS] Enrollment not found or you do not have permission to view it.</value></data>
-  <data name="Message.AlreadyCaptured" xml:space="preserve"><value>[XS] Consent has already been recorded as: </value></data>
-  <data name="Message.CanUpdate" xml:space="preserve"><value>[XS] You can update the consent level and signature below.</value></data>
+  <data name="Message.EnrollmentNotFound" xml:space="preserve"><value>A hi kumanga nkandziyiso kumbe awuna mpfumelelano wo vona.</value></data>
+  <data name="Message.AlreadyCaptured" xml:space="preserve"><value>Mpfumelelano wu tsariwile ikhale tani hi:</value></data>
+  <data name="Message.CanUpdate" xml:space="preserve"><value>Unga hundzula xiyimo xa mpfumelelano naku sayina laha hansi.</value></data>
   <data name="Message.Saving" xml:space="preserve"><value>Nvumelano wu hlayisiwa...</value></data>
-  <data name="Message.ValidationError" xml:space="preserve"><value>[XS] Please confirm the consent level before saving</value></data>
-  <data name="Message.ConsentRequired" xml:space="preserve"><value>[XS] Please select a consent option</value></data>
+  <data name="Message.ValidationError" xml:space="preserve"><value>Hi kombela u tiyisisa xiyimo xa mpfumelelano ungasi hlayisa.</value></data>
+  <data name="Message.ConsentRequired" xml:space="preserve"><value>Hi kombela u hlawula nxaxamelo wa mpfumelelano.</value></data>
   <data name="Message.SignatureRequired" xml:space="preserve"><value>Kusayina swi laveka — kombela u dirowa kusayina ka wena laha henhla</value></data>
   <data name="Message.Success" xml:space="preserve"><value>Nvumelano wa xifaniso wu hlayisiwile hi ndlela leyi humeleleke</value></data>
   <data name="Message.Error" xml:space="preserve"><value>Xihoxo xo hlayisa nvumelano wa xifaniso. Kombela u ringeta nakambe.</value></data>

--- a/Client/Resources/OpenEug.TenTrees.Module.Grower/Status.ts-ZA.resx
+++ b/Client/Resources/OpenEug.TenTrees.Module.Grower/Status.ts-ZA.resx
@@ -25,7 +25,7 @@
     <value>Tsala ku Huma eka Nongonoko</value>
   </data>
   <data name="Message.GrowerNotFound" xml:space="preserve">
-    <value>[XS] Grower not found or you do not have permission to view this grower.</value>
+    <value>Ahi kumanga murimi loyi, kumbe awuna mpfumelelano wo vona murimi loyi.</value>
   </data>
   <data name="Section.CurrentStatus" xml:space="preserve">
     <value>Xiyimo xa Sweswi</value>

--- a/Client/Resources/OpenEug.TenTrees.Module.Home/Index.resx
+++ b/Client/Resources/OpenEug.TenTrees.Module.Home/Index.resx
@@ -12,6 +12,36 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="Heading.Welcome" xml:space="preserve">
+    <value>Welcome to TenTrees Database</value>
+  </data>
+  <data name="TileName.Enrollment" xml:space="preserve">
+    <value>Enrollment</value>
+  </data>
+  <data name="TileName.Classes" xml:space="preserve">
+    <value>Classes</value>
+  </data>
+  <data name="TileName.Training" xml:space="preserve">
+    <value>Training</value>
+  </data>
+  <data name="TileName.Grower" xml:space="preserve">
+    <value>Grower</value>
+  </data>
+  <data name="TileName.Assessment" xml:space="preserve">
+    <value>Assessment</value>
+  </data>
+  <data name="TileName.Village" xml:space="preserve">
+    <value>Village</value>
+  </data>
+  <data name="TileName.Cohort" xml:space="preserve">
+    <value>Cohort</value>
+  </data>
+  <data name="TileName.Mentor" xml:space="preserve">
+    <value>Mentor</value>
+  </data>
+  <data name="TileName.TreeType" xml:space="preserve">
+    <value>Tree Type</value>
+  </data>
   <data name="Section.Workflow" xml:space="preserve">
     <value>Workflow</value>
   </data>

--- a/Client/Resources/OpenEug.TenTrees.Module.Home/Index.ts-ZA.resx
+++ b/Client/Resources/OpenEug.TenTrees.Module.Home/Index.ts-ZA.resx
@@ -12,6 +12,36 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="Heading.Welcome" xml:space="preserve">
+    <value>Amukelekile eka TenTrees Database</value>
+  </data>
+  <data name="TileName.Enrollment" xml:space="preserve">
+    <value>Nkandziyiso</value>
+  </data>
+  <data name="TileName.Classes" xml:space="preserve">
+    <value>Tiklasi</value>
+  </data>
+  <data name="TileName.Training" xml:space="preserve">
+    <value>Ku Leha</value>
+  </data>
+  <data name="TileName.Grower" xml:space="preserve">
+    <value>Mulimi</value>
+  </data>
+  <data name="TileName.Assessment" xml:space="preserve">
+    <value>Xikambelo</value>
+  </data>
+  <data name="TileName.Village" xml:space="preserve">
+    <value>Rixaka</value>
+  </data>
+  <data name="TileName.Cohort" xml:space="preserve">
+    <value>Cohort</value>
+  </data>
+  <data name="TileName.Mentor" xml:space="preserve">
+    <value>Muleriseri</value>
+  </data>
+  <data name="TileName.TreeType" xml:space="preserve">
+    <value>Muxaka wa Murhi</value>
+  </data>
   <data name="Section.Workflow" xml:space="preserve">
     <value>Ntirho</value>
   </data>


### PR DESCRIPTION
Enhances the Xitsonga language experience by:
- Localizing the home page welcome heading and navigation tile names for a fully translated initial view.
- Finalizing and correcting numerous Xitsonga resource strings across various modules, replacing placeholder translations with accurate and reviewed content.