### PR TITLE
localized menu

### DIFF
--- a/Client/Resources/OpenEug.TenTrees.Theme.TenTreesTheme/LocalizedMenu.resx
+++ b/Client/Resources/OpenEug.TenTrees.Theme.TenTreesTheme/LocalizedMenu.resx
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Home" xml:space="preserve">
+    <value>Home</value>
+  </data>
+  <data name="Enrollment" xml:space="preserve">
+    <value>Enrollment</value>
+  </data>
+  <data name="Classes" xml:space="preserve">
+    <value>Classes</value>
+  </data>
+  <data name="Training" xml:space="preserve">
+    <value>Training</value>
+  </data>
+  <data name="Grower" xml:space="preserve">
+    <value>Grower</value>
+  </data>
+  <data name="Assessment" xml:space="preserve">
+    <value>Assessment</value>
+  </data>
+  <data name="Admin" xml:space="preserve">
+    <value>Admin</value>
+  </data>
+  <data name="Village" xml:space="preserve">
+    <value>Village</value>
+  </data>
+  <data name="Cohort" xml:space="preserve">
+    <value>Cohort</value>
+  </data>
+  <data name="Mentor" xml:space="preserve">
+    <value>Mentor</value>
+  </data>
+  <data name="TreeType" xml:space="preserve">
+    <value>TreeType</value>
+  </data>
+</root>

--- a/Client/Resources/OpenEug.TenTrees.Theme.TenTreesTheme/LocalizedMenu.ts-ZA.resx
+++ b/Client/Resources/OpenEug.TenTrees.Theme.TenTreesTheme/LocalizedMenu.ts-ZA.resx
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Home" xml:space="preserve">
+    <value>Kaya</value>
+  </data>
+  <data name="Enrollment" xml:space="preserve">
+    <value>Nkandziyiso</value>
+  </data>
+  <data name="Classes" xml:space="preserve">
+    <value>Tiklasi</value>
+  </data>
+  <data name="Training" xml:space="preserve">
+    <value>Ku Leha</value>
+  </data>
+  <data name="Grower" xml:space="preserve">
+    <value>Mulimi</value>
+  </data>
+  <data name="Assessment" xml:space="preserve">
+    <value>Xikambelo</value>
+  </data>
+  <data name="Admin" xml:space="preserve">
+    <value>Vulawuri</value>
+  </data>
+  <data name="Village" xml:space="preserve">
+    <value>Rixaka</value>
+  </data>
+  <data name="Cohort" xml:space="preserve">
+    <value>Cohort</value>
+  </data>
+  <data name="Mentor" xml:space="preserve">
+    <value>Muleriseri</value>
+  </data>
+  <data name="TreeType" xml:space="preserve">
+    <value>Muxaka wa Murhi</value>
+  </data>
+</root>

--- a/Client/Themes/TenTreesTheme/LocalizedMenu.razor
+++ b/Client/Themes/TenTreesTheme/LocalizedMenu.razor
@@ -1,0 +1,15 @@
+@namespace OpenEug.TenTrees.Theme.TenTreesTheme
+
+@if (Orientation == "Vertical")
+{
+    <LocalizedMenuVertical />
+}
+else
+{
+    <LocalizedMenuHorizontal />
+}
+
+@code {
+    [Parameter]
+    public string Orientation { get; set; } = "Horizontal";
+}

--- a/Client/Themes/TenTreesTheme/LocalizedMenuBase.cs
+++ b/Client/Themes/TenTreesTheme/LocalizedMenuBase.cs
@@ -1,0 +1,20 @@
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Localization;
+using Oqtane.Models;
+using Oqtane.Themes.Controls;
+
+namespace OpenEug.TenTrees.Theme.TenTreesTheme
+{
+    public abstract class LocalizedMenuBase : MenuItemsBase
+    {
+        [Inject]
+        protected IStringLocalizer<LocalizedMenu> Localizer { get; set; }
+
+        // IStringLocalizer returns the key itself when no resource exists,
+        // so unmapped pages fall back to their raw database name.
+        protected string LocalizeName(Page page)
+        {
+            return Localizer[page.Name];
+        }
+    }
+}

--- a/Client/Themes/TenTreesTheme/LocalizedMenuHorizontal.razor
+++ b/Client/Themes/TenTreesTheme/LocalizedMenuHorizontal.razor
@@ -1,0 +1,16 @@
+@namespace OpenEug.TenTrees.Theme.TenTreesTheme
+@inherits MenuBase
+
+@if (MenuPages.Any())
+{
+    <span class="app-menu-toggler navbar-expand-md">
+        <button type="button" class="navbar-toggler" data-bs-toggle="collapse" data-bs-target="#Menu" aria-controls="Menu" aria-expanded="false" aria-label="Toggle Navigation">
+            <span class="navbar-toggler-icon"></span>
+        </button>
+    </span>
+    <div class="app-menu navbar-expand-md">
+        <div class="collapse navbar-collapse navbar-nav-scroll" id="Menu">
+            <LocalizedMenuItemsHorizontal ParentPage="null" Pages="MenuPages" />
+        </div>
+    </div>
+}

--- a/Client/Themes/TenTreesTheme/LocalizedMenuItemsHorizontal.razor
+++ b/Client/Themes/TenTreesTheme/LocalizedMenuItemsHorizontal.razor
@@ -1,0 +1,99 @@
+@namespace OpenEug.TenTrees.Theme.TenTreesTheme
+@inherits LocalizedMenuBase
+
+@if (ParentPage != null)
+{
+    <div class="dropdown-menu" aria-labelledby="@($"navbarDropdown{ParentPage.PageId}")">
+        @foreach (var childPage in GetChildPages())
+        {
+            var _attributes = new Dictionary<string, object>();
+            _attributes.Add("href", GetUrl(childPage));
+            var _target = GetTarget(childPage);
+            if (!string.IsNullOrEmpty(_target))
+            {
+                _attributes.Add("target", _target);
+            }
+            if (childPage.PageId == PageState.Page.PageId)
+            {
+                <a class="nav-link active px-3" @attributes="_attributes">
+                    <span class="w-100" data-bs-toggle="collapse" data-bs-target=".navbar-collapse.show">
+                        <span class="@childPage.Icon" aria-hidden="true" />
+                        @LocalizeName(childPage) <span class="visually-hidden-focusable">(current)</span>
+                    </span>
+                </a>
+            }
+            else
+            {
+                <a class="nav-link px-3" @attributes="_attributes">
+                    <span class="w-100" data-bs-toggle="collapse" data-bs-target=".navbar-collapse.show">
+                        <span class="@childPage.Icon" aria-hidden="true" />
+                        @LocalizeName(childPage)
+                    </span>
+                </a>
+            }
+        }
+    </div>
+}
+else
+{
+    <ul class="navbar-nav mr-auto">
+        @foreach (var childPage in GetChildPages())
+        {
+            var _attributes = new Dictionary<string, object>();
+            _attributes.Add("href", GetUrl(childPage));
+            var _target = GetTarget(childPage);
+            if (!string.IsNullOrEmpty(_target))
+            {
+                _attributes.Add("target", _target);
+            }
+            if (!Pages.Any(e => e.ParentId == childPage.PageId))
+            {
+                if (childPage.PageId == PageState.Page.PageId)
+                {
+                    <li class="nav-item">
+                        <a class="nav-link active" @attributes="_attributes">
+                            <span class="w-100" data-bs-toggle="collapse" data-bs-target=".navbar-collapse.show">
+                                <span class="@childPage.Icon" aria-hidden="true" />
+                                @LocalizeName(childPage) <span class="visually-hidden-focusable">(current)</span>
+                            </span>
+                        </a>
+                    </li>
+                }
+                else
+                {
+                    <li class="nav-item">
+                        <a class="nav-link" @attributes="_attributes">
+                            <span class="w-100" data-bs-toggle="collapse" data-bs-target=".navbar-collapse.show">
+                                <span class="@childPage.Icon" aria-hidden="true" />
+                                @LocalizeName(childPage)
+                            </span>
+                        </a>
+                    </li>
+                }
+            }
+            else
+            {
+                if (childPage.PageId == PageState.Page.PageId)
+                {
+                    <li class="nav-item dropdown active">
+                        <a class="nav-link dropdown-toggle" id="@($"navbarDropdown{childPage.PageId}")" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" @attributes="_attributes">
+                            <span class="@childPage.Icon" aria-hidden="true" />
+                            @LocalizeName(childPage) <span class="visually-hidden-focusable">(current)</span>
+                        </a>
+                        <LocalizedMenuItemsHorizontal ParentPage="childPage" Pages="Pages" />
+                    </li>
+                }
+                else
+                {
+                    <li class="nav-item dropdown">
+                        <a class="nav-link dropdown-toggle" id="@($"navbarDropdown{childPage.PageId}")" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" @attributes="_attributes">
+                            <span class="@childPage.Icon" aria-hidden="true" />
+                            @LocalizeName(childPage)
+                        </a>
+                        <LocalizedMenuItemsHorizontal ParentPage="childPage" Pages="Pages" />
+                    </li>
+                }
+            }
+        }
+    </ul>
+}

--- a/Client/Themes/TenTreesTheme/LocalizedMenuItemsVertical.razor
+++ b/Client/Themes/TenTreesTheme/LocalizedMenuItemsVertical.razor
@@ -1,0 +1,83 @@
+@namespace OpenEug.TenTrees.Theme.TenTreesTheme
+@inherits LocalizedMenuBase
+
+@if (ParentPage != null)
+{
+    foreach (var childPage in GetChildPages())
+    {
+        var _attributes = new Dictionary<string, object>();
+        _attributes.Add("href", GetUrl(childPage));
+        var _target = GetTarget(childPage);
+        if (!string.IsNullOrEmpty(_target))
+        {
+            _attributes.Add("target", _target);
+        }
+        if (childPage.PageId == PageState.Page.PageId)
+        {
+            <li class="nav-item px-3" style="margin-left: @(childPage.Level * 15)px;">
+                <a class="nav-link active" @attributes="_attributes">
+                    <span class="w-100" data-bs-toggle="collapse" data-bs-target=".navbar-collapse.show">
+                        <span class="@childPage.Icon" aria-hidden="true" />
+                        @LocalizeName(childPage) <span class="visually-hidden-focusable">(current)</span>
+                    </span>
+                </a>
+            </li>
+        }
+        else
+        {
+            <li class="nav-item px-3" style="margin-left: @(childPage.Level * 15)px;">
+                <a class="nav-link" @attributes="_attributes">
+                    <span class="w-100" data-bs-toggle="collapse" data-bs-target=".navbar-collapse.show">
+                        <span class="@childPage.Icon" aria-hidden="true" />
+                        @LocalizeName(childPage)
+                    </span>
+                </a>
+            </li>
+        }
+        if (Pages.Any(e => e.ParentId == childPage.PageId))
+        {
+            <LocalizedMenuItemsVertical ParentPage="childPage" Pages="Pages" />
+        }
+    }
+}
+else
+{
+    <ul class="nav flex-column">
+        @foreach (var childPage in GetChildPages())
+        {
+            var _attributes = new Dictionary<string, object>();
+            _attributes.Add("href", GetUrl(childPage));
+            var _target = GetTarget(childPage);
+            if (!string.IsNullOrEmpty(_target))
+            {
+                _attributes.Add("target", _target);
+            }
+            if (childPage.PageId == PageState.Page.PageId)
+            {
+                <li class="nav-item px-3" style="margin-left: @(childPage.Level * 15)px;">
+                    <a class="nav-link active" @attributes="_attributes">
+                        <span class="w-100" data-bs-toggle="collapse" data-bs-target=".navbar-collapse.show">
+                            <span class="@childPage.Icon" aria-hidden="true" />
+                            @LocalizeName(childPage) <span class="visually-hidden-focusable">(current)</span>
+                        </span>
+                    </a>
+                </li>
+            }
+            else
+            {
+                <li class="nav-item px-3" style="margin-left: @(childPage.Level * 15)px;">
+                    <a class="nav-link" @attributes="_attributes">
+                        <span class="w-100" data-bs-toggle="collapse" data-bs-target=".navbar-collapse.show">
+                            <span class="@childPage.Icon" aria-hidden="true" />
+                            @LocalizeName(childPage)
+                        </span>
+                    </a>
+                </li>
+            }
+            if (Pages.Any(e => e.ParentId == childPage.PageId))
+            {
+                <LocalizedMenuItemsVertical ParentPage="childPage" Pages="Pages" />
+            }
+        }
+    </ul>
+}

--- a/Client/Themes/TenTreesTheme/LocalizedMenuVertical.razor
+++ b/Client/Themes/TenTreesTheme/LocalizedMenuVertical.razor
@@ -1,0 +1,16 @@
+@namespace OpenEug.TenTrees.Theme.TenTreesTheme
+@inherits MenuBase
+
+@if (MenuPages.Any())
+{
+    <span class="app-menu-toggler">
+        <button type="button" class="navbar-toggler" data-bs-toggle="collapse" data-bs-target="#Menu" aria-controls="Menu" aria-expanded="false" aria-label="Toggle Navigation">
+            <span class="navbar-toggler-icon"></span>
+        </button>
+    </span>
+    <div class="app-menu">
+        <div class="collapse navbar-collapse" id="Menu">
+            <LocalizedMenuItemsVertical ParentPage="null" Pages="MenuPages" />
+        </div>
+    </div>
+}

--- a/Client/Themes/TenTreesTheme/Theme.razor
+++ b/Client/Themes/TenTreesTheme/Theme.razor
@@ -4,7 +4,7 @@
 
 <main role="main">
     <nav class="navbar navbar-dark bg-primary fixed-top">
-        <Logo /><Menu Orientation="Horizontal" />
+        <Logo /><LocalizedMenu Orientation="Horizontal" />
         <div class="controls ms-auto">
             <div class="controls-group"><UserMenu ShowLogin="@_login" ShowRegister="@_register" ButtonClass="btn btn-outline-light" /> <LanguagePicker ButtonClass="btn-outline-light" /> <ControlPanel ButtonClass="btn-outline-light" ShowLanguageSwitcher="false" /></div>
         </div>

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,0 +1,100 @@
+# Hand-off: Localized Navigation Menu (feature/localized-menu)
+
+Session hand-off for continuing work on another machine. Written 2026-07-15.
+Delete this file before merging the branch.
+
+## Goal
+
+Localize the top navigation menu (page names come from the `Page` table in the
+database, so Oqtane's built-in menu shows raw English names regardless of
+culture). Approach: a copy of Oqtane's menu control chain that looks up each
+`Page.Name` as a resx key via `IStringLocalizer`, falling back to the raw name
+when no key exists. This mirrors the framework's own precedent
+(`Oqtane.Client\Modules\Admin\Dashboard\Index.razor` localizes admin page names
+against `SharedResources` using the name as key).
+
+Stretch goal (deferred): upstream to oqtane/oqtane.framework — inject
+`IStringLocalizer<SharedResources>` into `MenuItemsBase` and render
+`SharedLocalizer[childPage.Name]`. Zero behavior change when no resource
+exists. Process: issue first, fork, branch from `dev`, PR to `dev` per
+CONTRIBUTING.md.
+
+## What's on this branch (commit 709fa17)
+
+All new files in `Client\Themes\TenTreesTheme\`, namespace
+`OpenEug.TenTrees.Theme.TenTreesTheme`:
+
+| File | Role |
+|---|---|
+| `LocalizedMenuBase.cs` | Inherits Oqtane's `MenuItemsBase`; injects `IStringLocalizer<LocalizedMenu>`; `LocalizeName(page)` returns `Localizer[page.Name]` (missing key ⇒ raw name) |
+| `LocalizedMenu.razor` | Orientation dispatcher (`Horizontal`/`Vertical`), compile-time switch |
+| `LocalizedMenuHorizontal.razor` / `LocalizedMenuVertical.razor` | Verbatim copies of stock `MenuHorizontal/Vertical` (inherit Oqtane `MenuBase`), pointing at the Localized items components |
+| `LocalizedMenuItemsHorizontal.razor` / `LocalizedMenuItemsVertical.razor` | Verbatim copies of stock items components; only change: `@childPage.Name` → `@LocalizeName(childPage)` |
+
+Resources (resolve via full-namespace folder because the Client project's root
+namespace doesn't prefix the theme namespace):
+
+- `Client\Resources\OpenEug.TenTrees.Theme.TenTreesTheme\LocalizedMenu.resx`
+- `Client\Resources\OpenEug.TenTrees.Theme.TenTreesTheme\LocalizedMenu.ts-ZA.resx`
+
+Keys: `Home, Enrollment, Classes, Training, Grower, Assessment, Admin,
+Village, Cohort, Mentor, TreeType`. ts-ZA values reuse the reviewed Home-tile
+strings (Nkandziyiso, Tiklasi, Ku Leha, Mulimi, Xikambelo, Vulawuri, Rixaka,
+Muleriseri, Muxaka wa Murhi). **"Kaya" (Home) is a new, unreviewed translation
+— flag for translation review.**
+
+Wire-up: `Client\Themes\TenTreesTheme\Theme.razor` line 7 —
+`<LocalizedMenu Orientation="Horizontal" />` (was `<Menu Orientation="Horizontal" />`).
+
+## Test status
+
+Done:
+- `dotnet build` clean (0 errors).
+- Menu structure/fallback verified — but only under the **default Oqtane
+  theme** (the dev site wasn't set to TenTreesTheme at the time), so the
+  localized control itself has NOT yet rendered successfully end-to-end.
+
+Not done (the actual test plan):
+1. Site set to TenTreesTheme, English: menu identical to before (Admin
+   dropdown, active-page `(current)` marker, mobile toggler).
+2. Switch to Xitsonga via the theme's LanguagePicker (full reload): navbar
+   shows Kaya / Nkandziyiso / Tiklasi / Mulimi / Xikambelo / Vulawuri etc.
+3. Fallback: any page without a matching key shows its raw DB name.
+4. Keyboard nav + aria attributes survived the copy.
+
+## Known issues / gotchas
+
+1. **Key = exact `Page.Name`, case-sensitive.** The Surf7 dev DB has a page
+   literally named `training` (lowercase) — it falls back to raw "training"
+   because the key is `Training`. Fix by renaming the page or adding a
+   lowercase key. Check the target DB's names first:
+   `SELECT Name, Path FROM [Page] WHERE IsNavigation = 1`.
+2. **White screen on Surf7 when TenTreesTheme is selected — NOT caused by this
+   branch.** Server prerender dies with `NullReferenceException` at
+   `OqtaneLocalizationExtensions.Create` ← `LocalizableComponent.OnParametersSet`
+   ← `Oqtane.Modules.Controls.Label.OnParametersSet` — i.e. some component
+   passes a `ResourceType` string that `Type.GetType()` can't resolve. No
+   TenTrees menu frames in the stack; none of the new files use `Label`.
+   Suspected stale type registration in that machine's ancient `Oqtane-TenTrees`
+   LocalDB. Response is HTTP 200 with a zero-length body; the real stack trace
+   is in the Oqtane `Log` table (`SELECT TOP 5 * FROM [Log] ORDER BY LogId DESC`).
+   If the theme renders fine on this PC's DB, that diagnosis is confirmed.
+3. **Connection strings are per-machine.** `appsettings.json` keeps named
+   variants (`DefaultConnectionSurf7`, `DefaultConnectionFold`); the active
+   `DefaultConnection` swap is intentionally NOT committed. Set it locally.
+4. This dev DB had no `Classes` or `Admin` navigation page (production does,
+   per the Discord screenshot) — those resx keys are dormant until tested
+   against a site that has them.
+
+## Reference notes (saves re-research)
+
+- Framework reference clone: `.oqtane-ref\` (git-ignored). Menu chain:
+  `.oqtane-ref\Oqtane.Client\Themes\Controls\Theme\Menu*.razor|cs`.
+- `MenuBase.MenuPages` already applies `IsNavigation` + view-permission
+  filtering; `GetUrl`/`GetTarget` handle external URLs and non-clickable pages.
+- Culture switching (theme `LanguagePicker.razor`) persists `User.CultureCode`
+  for logged-in users / sets the `.AspNetCore.Culture` cookie for anonymous,
+  then full-reloads — so the menu re-renders in the new culture with no cache
+  concerns.
+- `Page` model has no localization support at all (verified `Page.cs` incl.
+  `Clone()`); menu text is always `Page.Name`, browser tab is `Page.Title`.


### PR DESCRIPTION
#### PR Classification
New feature: Implements a localized navigation menu system for the TenTreesTheme in Oqtane.

#### PR Summary
Introduces new Blazor components to provide a localized navigation menu, replacing the default menu in the theme and supporting English and Xitsonga translations.
- Added `LocalizedMenu.razor` and related components to duplicate and localize the Oqtane menu structure using `IStringLocalizer`.
- Created `LocalizedMenu.resx` and `LocalizedMenu.ts-ZA.resx` resource files for English and Xitsonga navigation item translations.
- Updated `Theme.razor` to use the new `LocalizedMenu` component instead of the default menu.
- Added `HANDOFF.md` documenting implementation details, test status, and known issues.
